### PR TITLE
fix: add "private" property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,5 +64,6 @@
   "workspaces": [
     "website",
     "."
-  ]
+  ],
+  "private": true
 }


### PR DESCRIPTION
This solves console warnings, when using `react-rx` in a **yarn** environment, since **yarn** expects the property `"private": true`. 

```
warning Workspaces can only be enabled in private projects.
```