### PR TITLE
fix(useObservable)!: eagerly subscribe with delayed refcount expiry 

### DIFF
--- a/src/__tests__/strictmode.test.ts
+++ b/src/__tests__/strictmode.test.ts
@@ -39,7 +39,7 @@ test('Strict mode should trigger double mount effects and re-renders', async () 
   expect(mountCount).toEqual(2)
 })
 
-test('Strict mode should unsubscribe the source observable on unmount', () => {
+test('Strict mode should unsubscribe the source observable on unmount', async () => {
   const subscribed: number[] = []
   const unsubscribed: number[] = []
   let nextId = 0
@@ -57,12 +57,13 @@ test('Strict mode should unsubscribe the source observable on unmount', () => {
   }
 
   const {rerender} = render(createElement(StrictMode, null, createElement(ObservableComponent)))
-  expect(subscribed).toEqual([0, 1])
+  expect(subscribed).toEqual([0])
   rerender(createElement(StrictMode, null, createElement('div')))
-  expect(unsubscribed).toEqual([0, 1])
+  await Promise.resolve()
+  expect(unsubscribed).toEqual([0])
 })
 
-test('Strict mode should unsubscribe the source observable on unmount if its created in a useMemo', () => {
+test('Strict mode should unsubscribe the source observable on unmount if its created in a useMemo', async () => {
   let subscriberCount: number = 0
   const getObservable = () =>
     new Observable(() => {
@@ -81,5 +82,6 @@ test('Strict mode should unsubscribe the source observable on unmount if its cre
   const {rerender} = render(createElement(StrictMode, null, createElement(ObservableComponent)))
   expect(subscriberCount, 'Subscriber count should be 2').toBe(2)
   rerender(createElement(StrictMode, null, createElement('div')))
+  await Promise.resolve()
   expect(subscriberCount, 'Subscriber count should be 0').toBe(0)
 })

--- a/src/__tests__/useObservable.test-d.ts
+++ b/src/__tests__/useObservable.test-d.ts
@@ -22,6 +22,6 @@ test('useObservable with initial value if a different type returns a union of th
   const observable = of('foo')
 
   expectTypeOf(useObservable(observable, 1)).toEqualTypeOf<string | number>()
-
+  expectTypeOf(useObservable(observable, () => 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useObservable(observable, 'foo')).toEqualTypeOf<string>()
 })

--- a/src/__tests__/useObservable.test.ts
+++ b/src/__tests__/useObservable.test.ts
@@ -6,7 +6,7 @@ import {expect, test} from 'vitest'
 
 import {useObservable} from '../useObservable'
 
-test('should subscribe immediately on component mount and unsubscribe on component unmount', () => {
+test('should subscribe immediately on component mount and unsubscribe on component unmount', async () => {
   let subscribed = false
   const observable = new Observable(() => {
     subscribed = true
@@ -21,10 +21,11 @@ test('should subscribe immediately on component mount and unsubscribe on compone
   expect(subscribed).toBe(true)
 
   unmount()
+  await Promise.resolve()
   expect(subscribed).toBe(false)
 })
 
-test('should only subscribe once when given same observable on re-renders', () => {
+test('should only subscribe once when given same observable on re-renders', async () => {
   let subscriptionCount = 0
   const observable = new Observable(() => {
     subscriptionCount++
@@ -37,6 +38,7 @@ test('should only subscribe once when given same observable on re-renders', () =
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
+  await Promise.resolve()
 
   renderHook(() => useObservable(observable))
   expect(subscriptionCount).toBe(2)
@@ -103,7 +105,7 @@ test('should have passed initialValue as initial value from delayed observables'
   unmount()
 })
 
-test('should rerender with initial value if component unmounts and then remounts', () => {
+test('should rerender with initial value if component unmounts and then remounts', async () => {
   const values$ = new Subject<string>()
   const firstHook = renderHook(() => useObservable(values$, 'initial'))
 
@@ -113,13 +115,14 @@ test('should rerender with initial value if component unmounts and then remounts
   expect(firstHook.result.current).toBe('something')
 
   firstHook.unmount()
+  await Promise.resolve()
 
   const nextHook = renderHook(() => useObservable(values$, 'initial2'))
 
   expect(nextHook.result.current).toBe('initial2')
 })
 
-test('should share the observable between each concurrent subscribing hook', () => {
+test('should share the observable between each concurrent subscribing hook', async () => {
   let subscribeCount = 0
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
@@ -130,13 +133,14 @@ test('should share the observable between each concurrent subscribing hook', () 
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
+  await Promise.resolve()
 
   const thirdHook = renderHook(() => useObservable(observable))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
 
-test('should restart any completed observable on mount', () => {
+test('should restart any completed observable on mount', async () => {
   let subscribeCount = 0
   let unsubscribeCount = 0
 
@@ -178,12 +182,15 @@ test('should restart any completed observable on mount', () => {
   expect(unsubscribeCount).toBe(1)
 
   firstHook.unmount()
+  await Promise.resolve()
 
   const secondHook = renderHook(() => useObservable(observable))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
   secondHook.unmount()
+  await Promise.resolve()
+
   expect(unsubscribeCount).toBe(2)
 })
 

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -35,7 +35,7 @@ export function useObservable<ObservableType extends Observable<any>>(
 /** @public */
 export function useObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
-  initialValue: InitialValue,
+  initialValue: InitialValue | (() => InitialValue),
 ): InitialValue | ObservedValueOf<ObservableType>
 /** @public */
 export function useObservable<ObservableType extends Observable<any>, InitialValue>(


### PR DESCRIPTION
This changes how useObservable eagerly subscribes to given observables. The observable is now set up with reference counting that expires in the next tick, which simplifies how the sync value is pulled out of it and avoids excessive subscribe + unsubscribe passes. This fixes an issue in React Strict Mode, causing subscription leaks for observables created inside a useMemo(). See strictmode.test.ts for a failing test covering this issue.

BREAKING CHANGE:
This should normally not cause any problems, but given that it introduces a change in behavior wrt. timing of observable unsubscription, it can potentially cause race conditions in rare cases, especially if side-effects are performed in response to observable emissions.
The modifications required to make the test suite pass should be a good indication of the breaking nature of these changes, although the tests suites are in the majority of cases asserting internal behavior.