### PR TITLE
fix: refactor initial value to not need a useRef + useEffect loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rx",
-  "version": "4.0.0",
+  "version": "4.0.0-canary.0",
   "description": "React + RxJS = <3",
   "keywords": [
     "action",
@@ -92,7 +92,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.2",
-    "eslint-plugin-react-compiler": "0.0.0-experimental-9ed098e-20240725",
+    "eslint-plugin-react-compiler": "beta",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jsdom": "^24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^7.37.2
         version: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-compiler:
-        specifier: 0.0.0-experimental-9ed098e-20240725
-        version: 0.0.0-experimental-9ed098e-20240725(eslint@8.57.1)
+        specifier: beta
+        version: 19.0.0-beta-6fc168f-20241025(eslint@8.57.1)
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.0.0(eslint@8.57.1)
@@ -2625,8 +2625,8 @@ packages:
       eslint-config-prettier:
         optional: true
 
-  eslint-plugin-react-compiler@0.0.0-experimental-9ed098e-20240725:
-    resolution: {integrity: sha512-Xv2iD8kU6R4Wdjdh1WhdP8UnSqSV+/XcadxwBCmMr836fQUoXGuw/uVGc01v9opZs9SwKzo+8My6ayVCgAinPA==}
+  eslint-plugin-react-compiler@19.0.0-beta-6fc168f-20241025:
+    resolution: {integrity: sha512-mHn5tYt9dT4GiXHF5muiz6p+4Lirgi0Oc87N2KrbB/ciSkT+VZ8iJA+6bbS4//ljYzYbxBbPMHWS/dZWhQrbpQ==}
     engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
     peerDependencies:
       eslint: '>=7'
@@ -8347,7 +8347,7 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 9.1.0(eslint@8.57.1)
 
-  eslint-plugin-react-compiler@0.0.0-experimental-9ed098e-20240725(eslint@8.57.1):
+  eslint-plugin-react-compiler@19.0.0-beta-6fc168f-20241025(eslint@8.57.1):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/parser': 7.26.1

--- a/src/useObservable.ts
+++ b/src/useObservable.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef, useSyncExternalStore} from 'react'
+import {useMemo, useSyncExternalStore} from 'react'
 import {
   asapScheduler,
   catchError,
@@ -42,48 +42,35 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
   observable: ObservableType,
   initialValue?: InitialValue | (() => InitialValue),
 ): InitialValue | ObservedValueOf<ObservableType> {
-  /**
-   * Store the initialValue in a ref, as we don't want a changed `initialValue` to trigger a re-subscription.
-   * But we also don't want the initialValue to be stale if the observable changes.
-   */
-  const initialValueRef = useRef(getValue(initialValue) as ObservedValueOf<ObservableType>)
+  if (!cache.has(observable)) {
+    const entry: Partial<CacheRecord<ObservedValueOf<ObservableType>>> = {
+      snapshot: getValue(initialValue) as ObservedValueOf<ObservableType>,
+    }
+    entry.observable = observable.pipe(
+      map((value) => ({snapshot: value, error: undefined})),
+      catchError((error) => of({snapshot: undefined, error})),
+      tap(({snapshot, error}) => {
+        entry.snapshot = snapshot
+        entry.error = error
+      }),
+      // Note: any value or error emitted by the provided observable will be mapped to the cache entry's mutable state
+      // and the observable is thereafter only used as a notifier to call `onStoreChange`, hence the `void` return type.
+      map((value) => void value),
+      // Ensure that the cache entry is deleted when the observable completes or errors.
+      finalize(() => cache.delete(observable)),
+      share({resetOnRefCountZero: () => timer(0, asapScheduler)}),
+    )
 
-  /**
-   * Ensures that the initialValue is always up-to-date in case the observable changes.
-   */
-  useEffect(() => {
-    initialValueRef.current = getValue(initialValue) as ObservedValueOf<ObservableType>
-  }, [initialValue])
+    // Eagerly subscribe to sync set `entry.currentValue` to what the observable returns, and keep the observable alive until the component unmounts.
+    const subscription = entry.observable.subscribe()
+    subscription.unsubscribe()
+
+    cache.set(observable, entry as CacheRecord<ObservedValueOf<ObservableType>>)
+  }
 
   const store = useMemo(() => {
-    if (!cache.has(observable)) {
-      const entry: Partial<CacheRecord<ObservedValueOf<ObservableType>>> = {
-        snapshot: initialValueRef.current,
-      }
-      entry.observable = observable.pipe(
-        map((value) => ({snapshot: value, error: undefined})),
-        catchError((error) => of({snapshot: undefined, error})),
-        tap(({snapshot, error}) => {
-          entry.snapshot = snapshot
-          entry.error = error
-        }),
-        // Note: any value or error emitted by the provided observable will be mapped to the cache entry's mutable state
-        // and the observable is thereafter only used as a notifier to call `onStoreChange`, hence the `void` return type.
-        map((value) => void value),
-        // Ensure that the cache entry is deleted when the observable completes or errors.
-        finalize(() => cache.delete(observable)),
-        share({resetOnRefCountZero: () => timer(0, asapScheduler)}),
-      )
-
-      // Eagerly subscribe to sync set `entry.currentValue` to what the observable returns, and keep the observable alive until the component unmounts.
-      const subscription = entry.observable.subscribe()
-      subscription.unsubscribe()
-
-      cache.set(observable, entry as CacheRecord<ObservedValueOf<ObservableType>>)
-    }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const instance = cache.get(observable)!
-
     return {
       subscribe: (onStoreChange: () => void) => {
         const subscription = instance.observable.subscribe(onStoreChange)
@@ -103,6 +90,8 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
   return useSyncExternalStore<ObservedValueOf<ObservableType>>(
     store.subscribe,
     store.getSnapshot,
-    typeof initialValueRef.current === 'undefined' ? undefined : () => initialValueRef.current,
+    typeof initialValue === 'undefined'
+      ? undefined
+      : () => getValue(initialValue) as ObservedValueOf<ObservableType>,
   )
 }


### PR DESCRIPTION
By moving the `cache.has` and `cache.set` logic into the render body we no longer need the `useRef` + `useEffect` loop for ensuring that the initial value is up to date whenever it's needed by the init logic.
Not using `useRef` reduces our memory usage a tiny bit, and it's really nice to avoid the `useEffect` loop. Especially if the initial value is unstable in userland:

```ts
useObservable(observable, []) // <- the array is created on every render, causing the `useEffect` loop to run after every single render
```