### PR TITLE
chore: add minimumReleaseAge config to pnpm workspace conf

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,4 @@ packages:
 minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@sanity/*'
-  - '@portabletext/*'
   - 'use-effect-event'
-  - 'groq-js'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,9 @@
 packages:
   - 'website'
+
+minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - '@sanity/*'
+  - '@portabletext/*'
+  - 'use-effect-event'
+  - 'groq-js'


### PR DESCRIPTION
### Description
What it says on the tin: adds `minimumReleaseAge` (3 days) to pnpm workspace config