### PR TITLE
ci: add self-hosted Renovate GitHub Action

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,68 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # Every 2 hours
+  pull_request:
+    types: [closed]
+    branches: [current]
+  issues:
+    types: [edited]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    # Filter out noise: only run for schedule, manual dispatch, merged Renovate PRs,
+    # and human-edited issues (not bot updates to the Dependency Dashboard).
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'renovate/')) ||
+      (github.event_name == 'issues' && github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v3 # zizmor: ignore[github-app]
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Generate Renovate runner config
+        id: config
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          CONFIG_FILE="$GITHUB_WORKSPACE/.renovate-runner-config.json5"
+
+          cat > "$CONFIG_FILE" <<'EOF'
+          {
+            $schema: "https://docs.renovatebot.com/renovate-schema.json",
+            onboarding: false,
+            requireConfig: "optional",
+          EOF
+
+          echo "  repositories: [\"$REPOSITORY\"]," >> "$CONFIG_FILE"
+          echo '}' >> "$CONFIG_FILE"
+
+          echo "Generated config:"
+          cat "$CONFIG_FILE"
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@1a96852b0384df1837619d04c60b2d10d1f9ff08 # v46.1.21
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: .renovate-runner-config.json5
+        env:
+          GITHUB_COM_TOKEN: ${{ github.token }}
+          NODE_OPTIONS: '--max-old-space-size=4096'
+          LOG_LEVEL: debug


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a self-hosted Renovate workflow matching [sanity-io/plugins](https://github.com/sanity-io/plugins/blob/main/.github/workflows/renovate.yml).

## Changes

- New `.github/workflows/renovate.yml` that:
  - Runs every 2 hours, on manual dispatch, when Renovate PRs merge into `current`, and when humans edit issues (Dependency Dashboard checkboxes)
  - Authenticates via the Ecospark GitHub App (`vars.ECOSPARK_CLIENT_ID` + `secrets.ECOSPARK_APP_PRIVATE_KEY`)
  - Generates a minimal runner config and invokes `renovatebot/github-action@v46.1.21` (pinned by digest)

Existing `.github/renovate.json` is unchanged and continues to drive package rules via `github>sanity-io/renovate-config`.

## Notes

- PR closed trigger targets `current` (this repo’s default branch) instead of `main` as in plugins.
- Hosted Renovate has already been disabled for this repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c1ddacef-7b5c-4108-beee-8ceaa100eaed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c1ddacef-7b5c-4108-beee-8ceaa100eaed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

