### PR TITLE
ci: add pnpm dedupe-if-needed workflow

### DIFF
--- a/.github/workflows/pnpm-if-needed.yml
+++ b/.github/workflows/pnpm-if-needed.yml
@@ -1,0 +1,50 @@
+name: Dedupe lockfile
+
+on:
+  push:
+    branches: [current]
+    paths:
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    name: Can pnpm-lock.yaml be deduped? 🤔
+    runs-on: ubuntu-latest
+    # workflow_dispatch always lets you select the branch ref, even though in this case we only ever want to run the action on `current` thus we need an if check
+    if: ${{ github.ref_name == 'current' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup
+
+      - run: pnpm dedupe --config.ignore-scripts=true
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.ECOSPARK_CLIENT_ID }}
+          private-key: ${{ secrets.ECOSPARK_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
+        id: create-pull-request
+        with:
+          body: I ran `pnpm dedupe` 🧑‍💻
+          branch: actions/dedupe-if-needed
+          commit-message: 'chore(deps): dedupe pnpm-lock.yaml'
+          labels: 🤖 bot
+          sign-commits: true
+          title: 'chore(deps): dedupe pnpm-lock.yaml'
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Enable automerge on Pull Request
+        if: steps.create-pull-request.outputs.pull-request-operation == 'created'
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "$PR_NUMBER"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the lockfile dedupe automation from [`sanity-io/plugins`](https://github.com/sanity-io/plugins/blob/main/.github/workflows/pnpm-if-needed.yml), adapted for this repo:

- Triggers on pushes to `current` that touch `pnpm-lock.yaml` (plus manual `workflow_dispatch`)
- Runs `pnpm dedupe`, opens a PR on `actions/dedupe-if-needed` if anything changed, and enables squash automerge
- Uses the existing `./.github/actions/setup` composite action and Ecospark app token (`vars.ECOSPARK_CLIENT_ID` / `secrets.ECOSPARK_APP_PRIVATE_KEY`), matching Renovate

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b594b5d0-e68f-485e-b9f8-3ae3141f1aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b594b5d0-e68f-485e-b9f8-3ae3141f1aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

