### PR TITLE
chore: add grill-with-docs agent skill

### DIFF
--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: grill-with-docs
+description: A relentless interview to sharpen a plan or design, which also creates docs (ADR's and glossary) as we go.
+disable-model-invocation: true
+---
+
+Run a `/grilling` session, using the `/domain-modeling` skill.

--- a/.agents/skills/grill-with-docs/agents/openai.yaml
+++ b/.agents/skills/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "Grill a design and write its docs"
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/grill-with-docs
+++ b/.claude/skills/grill-with-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-with-docs

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "grill-with-docs": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/grill-with-docs/SKILL.md",
+      "computedHash": "9c460cbd94fd3c63cdef967dbdb6e66ca687103cdc380cd37834e4d10b738f78"
+    },
     "rxjs-like-a-pro": {
       "source": "bjoerge/rxjs-skills",
       "sourceType": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Installed [`grill-with-docs`](https://skills.sh/mattpocock/skills/grill-with-docs) from `mattpocock/skills` using the CLI’s default **symlink** mode:

```bash
npx skills add https://github.com/mattpocock/skills --skill grill-with-docs --agent '*' -y
```

Layout:
- Canonical skill under `.agents/skills/grill-with-docs/`
- Claude Code symlink at `.claude/skills/grill-with-docs` → `../../.agents/skills/grill-with-docs`
- `skills-lock.json` pins source/hash

Note: `--agent '*'` also targets Eve, which always materializes a rewritten copy under `agent/skills/` (it strips `name` from frontmatter, so it cannot share the canonical files via symlink). That Eve tree was removed because this repo is not an Eve project.

Same layout as the existing `rxjs-like-a-pro` skill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323ff09b-895e-423b-86f6-89a5378c80c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323ff09b-895e-423b-86f6-89a5378c80c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

