### PR TITLE
chore: drop redundant nextra>zod override

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,6 @@ catalogs:
       version: 1.0.0
 
 overrides:
-  nextra>zod: 4.3.6
   nextra-theme-docs>zod: 4.3.6
 
 importers:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,8 +19,7 @@ minimumReleaseAgeExclude:
   - 'oxlint-tsgolint'
   - 'use-effect-event'
 
-# nextra 4.6.1 is incompatible with zod 4.4.x (Layout children validation).
+# nextra-theme-docs 4.6.1 Layout breaks on zod 4.4.x (children stripped before safeParse).
 # Remove when a release includes shuding/nextra#4990 (not published yet; latest is 4.6.1).
 overrides:
-  'nextra>zod': 4.3.6
   'nextra-theme-docs>zod': 4.3.6


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Yes — keep only `nextra-theme-docs>zod`.

The zod 4.4.x Layout failure is in **nextra-theme-docs** (`Layout` strips `children` before `safeParse`; fixed in [shuding/nextra#4990](https://github.com/shuding/nextra/pull/4990), not published yet). Core `nextra` does not need the pin.

With only the theme override, pnpm still dedupes `nextra` onto the same `zod@4.3.6`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-229292df-7942-4d45-b741-7bda5096a5b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-229292df-7942-4d45-b741-7bda5096a5b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

