### PR TITLE
chore(deps): use ^1.0.0 for react-compiler-runtime

### DIFF
--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "observable-callback": "^1.0.3",
-    "react-compiler-runtime": "1.0.0",
+    "react-compiler-runtime": "^1.0.0",
     "use-effect-event": "^2.0.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3(rxjs@7.8.2)
       react-compiler-runtime:
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0(react@19.2.8)
       use-effect-event:
         specifier: ^2.0.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the `react-compiler-runtime` dependency in `react-rx` from a pinned `1.0.0` to a caret range `^1.0.0`, matching the other runtime dependencies and allowing compatible 1.x updates.

Resolved version remains `1.0.0`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-990b35e7-b3dc-426e-8f14-fca9cf84c767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-990b35e7-b3dc-426e-8f14-fca9cf84c767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

