### PR TITLE
chore(deps): update dependency bezier-easing to v3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,8 +130,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       bezier-easing:
-        specifier: ^2.1.0
-        version: 2.1.0
+        specifier: ^3.0.1
+        version: 3.0.1
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -2266,8 +2266,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  bezier-easing@2.1.0:
-    resolution: {integrity: sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==}
+  bezier-easing@3.0.1:
+    resolution: {integrity: sha512-vvvg10Anq7py0+KkIqlwJpUVdde9Z8kSzeUzAkQNYAJdA3mZnLG9r9ExdwtjcASCYER6UkNHdBNHHMnVimnU7A==}
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
@@ -6266,7 +6266,7 @@ snapshots:
       mathjax-full: 3.2.2
       react: 19.2.8
 
-  bezier-easing@2.1.0: {}
+  bezier-easing@3.0.1: {}
 
   bidi-js@1.0.3:
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "bezier-easing": "^2.1.0",
+    "bezier-easing": "^3.0.1",
     "date-fns": "^4.4.0",
     "next": "^16.2.12",
     "nextra": "^4.6.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps `bezier-easing` from `^2.1.0` to `^3.0.1` in the website workspace.

### Investigation

`bezier-easing` is only used by the docs site animation Sandpack example:

- `website/package.json` — runtime dependency
- `website/src/examples/animation/AnimationExample.tsx` — `import bezier from 'bezier-easing'`, then `bezier(x1, y1, x2, y2)` to build easing functions
- `website/src/examples/animation/index.tsx` — Sandpack already pins `'bezier-easing': 'latest'`

### Compatibility

v3 keeps the same default-export factory API. It switches to ESM (`"type": "module"`) with dual `exports` (`import` / `require`) and replaces Newton–Raphson with Cardano’s algebraic solver. All easing curves used in the animation example (including overshoot “back” curves with y outside `[0, 1]`) produce valid non-NaN outputs under v3, so no call-site changes were needed.

## Test plan

- [x] Verified all `EASINGS` factory calls from `AnimationExample.tsx` against `bezier-easing@3.0.1`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `tsc --noEmit` in `website`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3d9d1fbe-1b27-43dd-8a7e-0bf43cb76b56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d9d1fbe-1b27-43dd-8a7e-0bf43cb76b56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

