### PR TITLE
docs: remove reactiveComponent refs and document useObservableEvent

### DIFF
--- a/packages/react-rx/README.md
+++ b/packages/react-rx/README.md
@@ -16,7 +16,7 @@ This package provides React hooks for working with RxJS Observables in your comp
 
 - [Guide](https://react-rx.dev/guide)
 - [API reference](https://react-rx.dev/reference)
-- [Code examples](https://react-rx.dev/examples)
+- [Code examples](https://react-rx.dev/examples/simple)
 
 ---
 

--- a/packages/react-rx/README.md
+++ b/packages/react-rx/README.md
@@ -10,17 +10,12 @@ Features:
 - Lightweight. Implemented on top of a small React Hook based core.
 - Full TypeScript support.
 
-This package offers two slightly different utilities for working with RxJS and React:
-
-- A set of utilities for creating _Reactive components_
-- A set of React hooks for using with observables with React
-
-Although they share a lot of similarities, and reactiveComponent is built on top of `useObservable` are not intended to be used together inside the same component as they represent two different programming styles.
+This package provides React hooks for working with RxJS Observables in your components.
 
 ---
 
-- [Reactive components](https://react-rx.dev/guide#reactive-components)
-- [Observable hooks](https://react-rx.dev/guide#observable-hooks)
+- [Guide](https://react-rx.dev/guide)
+- [API reference](https://react-rx.dev/reference)
 - [Code examples](https://react-rx.dev/examples)
 
 ---

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -48,7 +48,7 @@ function MyComponent(props) {
 The `disabled` option is optional. If its omitted, the hook will subscribe to the observable and return the current value. If its `true` initially, the hook will not subscribe to the observable and return the `initialValue` if provided. In the event that it has already subscribed it will then unsubscribe from the observable and return the last value it received.
 
 ```tsx
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {Subject} from 'rxjs'
 
@@ -78,10 +78,10 @@ import {useObservableEvent} from 'react-rx'
 import {filter, map, tap} from 'rxjs/operators'
 
 const ShowSliderValue = () => {
-  const [value, setValue] = useState(0)
+  const [value, setValue] = useState(1)
   const handleChange = useObservableEvent((value$) =>
     value$.pipe(
-      // Ignore null values
+      // Ignore nullish values
       filter(nonNullable),
       // Cast to number
       map((value) => Number(value)),
@@ -105,6 +105,6 @@ const ShowSliderValue = () => {
 }
 
 function nonNullable<T>(v: T): v is NonNullable<T> {
-  return v !== null
+  return v != null
 }
 ```

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -38,7 +38,7 @@ import {of} from 'rxjs'
 
 // This component will never render "Hello mars!" since the observable emits "world" synchronously.
 function MyComponent(props) {
-  const observable = useMemo() => of('world'),[])
+  const observable = useMemo(() => of('world'), [])
   const planet = useObservable(observable, 'mars')
 
   return <>Hello {planet}!</>
@@ -48,18 +48,19 @@ function MyComponent(props) {
 The `disabled` option is optional. If its omitted, the hook will subscribe to the observable and return the current value. If its `true` initially, the hook will not subscribe to the observable and return the `initialValue` if provided. In the event that it has already subscribed it will then unsubscribe from the observable and return the last value it received.
 
 ```tsx
-import {useMemo} from 'react'
+import {useEffect, useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
-import {of} from 'rxjs'
+import {Subject} from 'rxjs'
 
-// This component will never render "Hello world!" since the observable emits "world" asynchronously and the disabled option is true.
+// This component will never render "Hello world!" while `disabled` is true,
+// even if the subject emits asynchronously.
 function MyComponent(props) {
-  const observable = useMemo() => of(),[])
+  const [observable] = useState(() => new Subject<string>())
   const planet = useObservable(observable, 'mars', {disabled: true})
 
   useEffect(() => {
     observable.next('world')
-  },[observable])
+  }, [observable])
 
   return <>Hello {planet}!</>
 }

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -19,6 +19,21 @@ interface UseObservableOptions {
 }
 ```
 
+**Example**
+
+```tsx
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {interval} from 'rxjs'
+
+function MyComponent() {
+  const observable = useMemo(() => interval(100), [])
+  const number = useObservable(observable, 0)
+
+  return <>The number is {number}</>
+}
+```
+
 ## useObservableEvent()
 
 A React hook that turns an event handler into an observable stream. Pass a function that receives an observable of events and returns an observable of side effects; the hook returns a stable callback you can attach to DOM or component event props.

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -1,5 +1,3 @@
-import {Callout} from 'nextra/components'
-
 # React hooks
 
 ## useObservable()
@@ -23,4 +21,53 @@ interface UseObservableOptions {
 
 ## useObservableEvent()
 
-<Callout emoji="🚨">This page is a stub. Help us expand it by contributing!</Callout>
+A React hook that turns an event handler into an observable stream. Pass a function that receives an observable of events and returns an observable of side effects; the hook returns a stable callback you can attach to DOM or component event props.
+
+When the returned callback is invoked, each argument is pushed into the observable. The pipeline you return is subscribed for the lifetime of the component, and unsubscribed on unmount.
+
+**Signature**
+
+```ts
+function useObservableEvent<T, U>(
+  handleEvent: (arg: Observable<T>) => Observable<U>,
+): (arg: T) => void
+```
+
+**Example**
+
+```tsx
+import {useState} from 'react'
+import {useObservableEvent} from 'react-rx'
+import {filter, map, tap} from 'rxjs/operators'
+
+const ShowSliderValue = () => {
+  const [value, setValue] = useState(0)
+  const handleChange = useObservableEvent((value$) =>
+    value$.pipe(
+      // Ignore null values
+      filter(nonNullable),
+      // Cast to number
+      map((value) => Number(value)),
+      // Update local state
+      tap(setValue),
+    ),
+  )
+
+  return (
+    <>
+      <input
+        type="range"
+        value={value}
+        onChange={(event) => handleChange(event.target.value)}
+        min={1}
+        max={10}
+      />
+      <div>Value is: {value}</div>
+    </>
+  )
+}
+
+function nonNullable<T>(v: T): v is NonNullable<T> {
+  return v !== null
+}
+```

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -23,7 +23,7 @@ interface UseObservableOptions {
 
 A React hook that turns an event handler into an observable stream. Pass a function that receives an observable of events and returns an observable of side effects; the hook returns a stable callback you can attach to DOM or component event props.
 
-When the returned callback is invoked, each argument is pushed into the observable. The pipeline you return is subscribed for the lifetime of the component, and unsubscribed on unmount.
+When the returned callback is invoked, its single argument is emitted into the observable. The pipeline you return is subscribed for the lifetime of the component, and unsubscribed on unmount.
 
 **Signature**
 
@@ -41,10 +41,10 @@ import {useObservableEvent} from 'react-rx'
 import {filter, map, tap} from 'rxjs/operators'
 
 const ShowSliderValue = () => {
-  const [value, setValue] = useState(0)
+  const [value, setValue] = useState(1)
   const handleChange = useObservableEvent((value$) =>
     value$.pipe(
-      // Ignore null values
+      // Ignore nullish values
       filter(nonNullable),
       // Cast to number
       map((value) => Number(value)),
@@ -68,6 +68,6 @@ const ShowSliderValue = () => {
 }
 
 function nonNullable<T>(v: T): v is NonNullable<T> {
-  return v !== null
+  return v != null
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes outdated `reactiveComponent` / “Reactive components” copy from the package README (also linked from the repo root), replaces the API stub for `useObservableEvent` with a real description, signature, and example, and fixes broken `useMemo` snippets in the guide’s `useObservable` section.

Also points the README “Code examples” link at `/examples/simple`, since `/examples` 404s.

Addressed Copilot review feedback: unused import, slider initial value, `nonNullable` type guard, and clearer callback wording. Added a matching `useObservable` example on the API page so both hooks document consistently.

No code changes — documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e522673f-6431-4617-8ff4-7375eb382297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e522673f-6431-4617-8ff4-7375eb382297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

