### PR TITLE
feat!: require Node.js >=22.12 (match sanity engines)

### DIFF
--- a/.changeset/node-engines-22.md
+++ b/.changeset/node-engines-22.md
@@ -1,0 +1,7 @@
+---
+"react-rx": major
+---
+
+Require Node.js `>=22.12`, matching `sanity`'s `engines.node` field.
+
+Packages that declare an incompatible Node engine may see install warnings or failures under strict engine checks (`engine-strict` / `--engine-strict`).

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -104,5 +104,8 @@
   "peerDependencies": {
     "react": "^18.3 || >=19.0.0-0",
     "rxjs": "^7"
+  },
+  "engines": {
+    "node": ">=22.12"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Align `react-rx`'s `engines.node` with `sanity@latest` (`>=22.12`).

Previously the package had no `engines` field (publint warned about the missing `engines.node`). This declares the same Node requirement as Sanity and is a **breaking change** for consumers on older Node versions under strict engine checks.

Includes a major Changesets entry so the next release bumps to v5 (as a `next` pre-release while the repo is in pre mode).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42a2068e-4d1e-4208-987b-fe6987aa0cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42a2068e-4d1e-4208-987b-fe6987aa0cfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

