### PR TITLE
feat!: require React ^19.2 as peer dependency

### DIFF
--- a/.changeset/react-peer-19-2.md
+++ b/.changeset/react-peer-19-2.md
@@ -1,0 +1,5 @@
+---
+"react-rx": major
+---
+
+**BREAKING:** Require React `^19.2` as a peer dependency. React 18 is no longer supported.

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -14,7 +14,6 @@
     "observe",
     "pipe",
     "react",
-    "react18",
     "react19",
     "reactive",
     "realtime",
@@ -102,7 +101,7 @@
     "vitest": "^4.1.10"
   },
   "peerDependencies": {
-    "react": "^18.3 || >=19.0.0-0",
+    "react": "^19.2",
     "rxjs": "^7"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drop React 18 from the `react` peer dependency range. `react-rx` now requires React `^19.2`.

### Changes
- `peerDependencies.react`: `^18.3 || >=19.0.0-0` → `^19.2`
- Remove the `react18` package keyword
- Major changeset for the breaking peer-range change

This is a breaking change for consumers still on React 18.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58dea081-76f5-4894-ac21-9322d86b59dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58dea081-76f5-4894-ac21-9322d86b59dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

