### PR TITLE
refactor: use native React.useEffectEvent

### DIFF
--- a/.changeset/native-use-effect-event.md
+++ b/.changeset/native-use-effect-event.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Use React's native `useEffectEvent` instead of the `use-effect-event` polyfill.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
       "semanticCommitType": "chore"
     },
     {
-      "matchPackageNames": ["observable-callback", "use-effect-event"],
+      "matchPackageNames": ["observable-callback"],
       "rangeStrategy": "bump",
       "semanticCommitType": "fix"
     },

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -74,8 +74,7 @@
   },
   "dependencies": {
     "observable-callback": "^1.0.3",
-    "react-compiler-runtime": "^1.0.0",
-    "use-effect-event": "^2.0.3"
+    "react-compiler-runtime": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/packages/react-rx/src/useObservableEvent.ts
+++ b/packages/react-rx/src/useObservableEvent.ts
@@ -1,7 +1,6 @@
 import {observableCallback} from 'observable-callback'
-import {useEffect, useState} from 'react'
+import {useEffect, useEffectEvent, useState} from 'react'
 import {type Observable} from 'rxjs'
-import {useEffectEvent} from 'use-effect-event'
 
 /** @public */
 export function useObservableEvent<T, U>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       react-compiler-runtime:
         specifier: ^1.0.0
         version: 1.0.0(react@19.2.8)
-      use-effect-event:
-        specifier: ^2.0.3
-        version: 2.0.3(react@19.2.8)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -4002,11 +3999,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  use-effect-event@2.0.3:
-    resolution: {integrity: sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==}
-    peerDependencies:
-      react: ^18.3 || ^19.0.0-0
 
   use-error-boundary@2.0.6:
     resolution: {integrity: sha512-AWCVKSAanLe6R/on/ZkHYtGKfXs8BQX6z/TUGYqtvkajLqQyrGKJJscbahtq8OyN8L3LqTRjJWx4gCOLmfIObw==}
@@ -8431,10 +8423,6 @@ snapshots:
       browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  use-effect-event@2.0.3(react@19.2.8):
-    dependencies:
-      react: 19.2.8
 
   use-error-boundary@2.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Drop the `use-effect-event` polyfill in favor of React's native `useEffectEvent`, which is available now that React `^19.2` is required as a peer dependency.

## Changes
- Import `useEffectEvent` from `react` in `useObservableEvent`
- Remove the `use-effect-event` dependency
- Drop it from Renovate package rules

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-316b152f-6b61-4e0e-8e06-691b8320685d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-316b152f-6b61-4e0e-8e06-691b8320685d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

