### PR TITLE
refactor: vendor observableCallback and drop the dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,11 +9,6 @@
       "semanticCommitType": "chore"
     },
     {
-      "matchPackageNames": ["observable-callback"],
-      "rangeStrategy": "bump",
-      "semanticCommitType": "fix"
-    },
-    {
       "matchPackageNames": ["oxlint", "oxlint-tsgolint"],
       "groupName": "oxlint",
       "semanticCommitType": "chore"

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -72,9 +72,6 @@
     "test": "vitest run --typecheck",
     "watch": "tsdown --watch"
   },
-  "dependencies": {
-    "observable-callback": "^1.0.3"
-  },
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@rolldown/plugin-babel": "^0.2.3",

--- a/packages/react-rx/src/observableCallback.ts
+++ b/packages/react-rx/src/observableCallback.ts
@@ -1,0 +1,10 @@
+import {type Observable, Subject} from 'rxjs'
+
+/**
+ * Vendored from https://github.com/bjoerge/observable-callback
+ * (only the overload we need).
+ */
+export function observableCallback<T>(): [Observable<T>, (arg: T) => void] {
+  const subject = new Subject<T>()
+  return [subject.asObservable(), (arg: T) => subject.next(arg)]
+}

--- a/packages/react-rx/src/useObservableEvent.ts
+++ b/packages/react-rx/src/useObservableEvent.ts
@@ -1,6 +1,7 @@
-import {observableCallback} from 'observable-callback'
 import {useEffect, useEffectEvent, useState} from 'react'
 import {type Observable} from 'rxjs'
+
+import {observableCallback} from './observableCallback'
 
 /** @public */
 export function useObservableEvent<T, U>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,10 +37,6 @@ importers:
         version: 7.0.2
 
   packages/react-rx:
-    dependencies:
-      observable-callback:
-        specifier: ^1.0.3
-        version: 1.0.3(rxjs@7.8.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -138,9 +134,6 @@ importers:
       nextra-theme-docs:
         specifier: ^4.6.1
         version: 4.6.1(@types/react@19.2.17)(next@16.2.12(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(nextra@4.6.1(next@16.2.12(@babel/core@7.29.7)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@6.0.3))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
-      observable-callback:
-        specifier: ^1.0.3
-        version: 1.0.3(rxjs@7.8.2)
       react:
         specifier: ^19.2.8
         version: 19.2.8
@@ -3272,12 +3265,6 @@ packages:
   npm-to-yarn@3.2.0:
     resolution: {integrity: sha512-K1HmQeZT2HrjpsR6KgqbN2FAXL2NrJJmNUSD9ck7HGTVu1JKXox8n9SB+tjbU8m8JGLF4OscrroPepew/L7/Xw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  observable-callback@1.0.3:
-    resolution: {integrity: sha512-VlS275UyPnwdMtzxDgr/lCiOUyq9uXNll3vdwzDcJ6PB/LuO7gLmxAQopcCA3JoFwwujBwyA7/tP5TXZwWSXew==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      rxjs: ^6.5 || ^7
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -7525,10 +7512,6 @@ snapshots:
       path-key: 4.0.0
 
   npm-to-yarn@3.2.0: {}
-
-  observable-callback@1.0.3(rxjs@7.8.2):
-    dependencies:
-      rxjs: 7.8.2
 
   obug@2.1.4: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -20,7 +20,6 @@
     "next": "^16.2.12",
     "nextra": "^4.6.1",
     "nextra-theme-docs": "^4.6.1",
-    "observable-callback": "^1.0.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-rx": "workspace:*",

--- a/website/src/components/Sandpack.tsx
+++ b/website/src/components/Sandpack.tsx
@@ -76,7 +76,6 @@ export default function SandpackComponent({
            * while locally we use the build package
            */
           ...(reactRxSource ? {} : {'react-rx': reactRxPackageJson.version}),
-          ...reactRxPackageJson.dependencies,
           'rxjs': reactRxPackageJson.peerDependencies.rxjs,
           'react': reactRxPackageJson.devDependencies.react,
           'react-dom': reactRxPackageJson.devDependencies['react-dom'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Vendors the small `observableCallback` helper used by `useObservableEvent` instead of depending on `observable-callback`.

### Changes
- Add a local `observableCallback` with only the overload we use
- Remove `observable-callback` from `react-rx` and the website
- Drop the Renovate rule for that package
- Stop spreading `react-rx` `dependencies` into Sandpack now that there are none

`pnpm lint` and `pnpm --filter react-rx test` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12e22643-82ce-4616-9ed8-02c27ef0f7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12e22643-82ce-4616-9ed8-02c27ef0f7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

