### PR TITLE
chore: add changeset for vendoring observableCallback

### DIFF
--- a/.changeset/vendor-observable-callback.md
+++ b/.changeset/vendor-observable-callback.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Vendor `observableCallback` into the package and drop the `observable-callback` dependency.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the missing patch changeset for #443 (vendoring `observableCallback` and dropping the `observable-callback` dependency).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12e22643-82ce-4616-9ed8-02c27ef0f7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12e22643-82ce-4616-9ed8-02c27ef0f7bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

