### PR TITLE
refactor: import RxJS operators from `rxjs`, require peer `^7.2`

### DIFF
--- a/.agents/skills/rxjs-like-a-pro/SKILL.md
+++ b/.agents/skills/rxjs-like-a-pro/SKILL.md
@@ -2,7 +2,7 @@
 name: rxjs-like-a-pro
 description: >
   How to write idiomatic, efficient RxJS code. Use this skill whenever the user is writing, refactoring,
-  reviewing, or debugging code that uses RxJS — including any file that imports from 'rxjs' or 'rxjs/operators'.
+  reviewing, or debugging code that uses RxJS — including any file that imports from 'rxjs'.
   Trigger on mentions of observables, subscriptions, RxJS operators, or reactive streams. Even if the user
   doesn't say "RxJS" explicitly, activate when you see patterns like `.pipe()`, `.subscribe()`, `Observable`,
   `Subject`, `BehaviorSubject`, `switchMap`, `mergeMap`, or similar.

--- a/.agents/skills/rxjs-like-a-pro/references/custom-operators.md
+++ b/.agents/skills/rxjs-like-a-pro/references/custom-operators.md
@@ -30,8 +30,13 @@ When you use the same inline operator in multiple places, extract it into a name
 `OperatorFunction<In, Out>` as the return type so it slots cleanly into any `.pipe()` chain:
 
 ```typescript
-import {OperatorFunction, Observable} from 'rxjs'
-import {debounceTime, distinctUntilChanged, filter} from 'rxjs/operators'
+import {
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  type Observable,
+  type OperatorFunction,
+} from 'rxjs'
 
 interface StabilizeOptions {
   debounce?: number

--- a/.agents/skills/rxjs-like-a-pro/references/loading-state-patterns.md
+++ b/.agents/skills/rxjs-like-a-pro/references/loading-state-patterns.md
@@ -19,8 +19,15 @@ const dataWithLoadingState$ = input$.pipe(
 ## Extract into a reusable custom operator
 
 ```typescript
-import {OperatorFunction, Observable, of} from 'rxjs'
-import {switchMap, map, catchError, startWith} from 'rxjs/operators'
+import {
+  catchError,
+  map,
+  type Observable,
+  of,
+  type OperatorFunction,
+  startWith,
+  switchMap,
+} from 'rxjs'
 
 type LoadingState<T> =
   {loading: true} | {loading: false; data: T} | {loading: false; error: unknown}

--- a/.changeset/rxjs-import-consolidate.md
+++ b/.changeset/rxjs-import-consolidate.md
@@ -1,0 +1,5 @@
+---
+"react-rx": major
+---
+
+**BREAKING:** Require RxJS `^7.2` as a peer dependency (operators are imported from `'rxjs'`, which landed in 7.2). Import operators from `'rxjs'` instead of the deprecated `'rxjs/operators'` path.

--- a/packages/react-rx/README.md
+++ b/packages/react-rx/README.md
@@ -12,6 +12,11 @@ Features:
 
 This package provides React hooks for working with RxJS Observables in your components.
 
+## Requirements
+
+- React `^19.2`
+- RxJS `^7.2` — operators are imported from `'rxjs'` (not the deprecated `'rxjs/operators'` path). If you're still on an older RxJS, see the [RxJS import migration guide](https://rxjs.dev/guide/importing#how-to-migrate).
+
 ---
 
 - [Guide](https://react-rx.dev/guide)

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -91,7 +91,7 @@
   },
   "peerDependencies": {
     "react": "^19.2",
-    "rxjs": "^7"
+    "rxjs": "^7.2"
   },
   "engines": {
     "node": ">=22.12"

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -1,8 +1,17 @@
 import {act, render, renderHook} from '@testing-library/react'
 import {useMemo} from 'react'
 import {renderToString} from 'react-dom/server'
-import {asyncScheduler, Observable, of, ReplaySubject, scheduled, share, Subject, timer} from 'rxjs'
-import {map} from 'rxjs/operators'
+import {
+  asyncScheduler,
+  map,
+  Observable,
+  of,
+  ReplaySubject,
+  scheduled,
+  share,
+  Subject,
+  timer,
+} from 'rxjs'
 import {expect, test} from 'vitest'
 
 import {useObservable, type UseObservableOptions} from '../useObservable'

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -3,13 +3,14 @@ import {
   asapScheduler,
   catchError,
   finalize,
+  map,
   type Observable,
   type ObservedValueOf,
   of,
   share,
+  tap,
   timer,
 } from 'rxjs'
-import {map, tap} from 'rxjs/operators'
 
 function getValue<T>(value: T): T extends () => infer U ? U : T {
   return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -75,7 +75,7 @@ Here's an example of a component that displays the current value from a range in
 ```tsx
 import {useState} from 'react'
 import {useObservableEvent} from 'react-rx'
-import {filter, map, tap} from 'rxjs/operators'
+import {filter, map, tap} from 'rxjs'
 
 const ShowSliderValue = () => {
   const [value, setValue] = useState(1)

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -53,7 +53,7 @@ function useObservableEvent<T, U>(
 ```tsx
 import {useState} from 'react'
 import {useObservableEvent} from 'react-rx'
-import {filter, map, tap} from 'rxjs/operators'
+import {filter, map, tap} from 'rxjs'
 
 const ShowSliderValue = () => {
   const [value, setValue] = useState(1)

--- a/website/src/examples/animation/AnimationExample.tsx
+++ b/website/src/examples/animation/AnimationExample.tsx
@@ -4,13 +4,14 @@ import {
   useObservable,
   useObservableEvent,
 } from 'react-rx'
-import {Subject, timer} from 'rxjs'
 import {
   map,
   startWith,
+  Subject,
   switchMap,
   tap,
-} from 'rxjs/operators'
+  timer,
+} from 'rxjs'
 import {styled} from 'styled-components'
 
 const BALL_SIZE = 30

--- a/website/src/examples/event-handlers/EventHandlersExample.tsx
+++ b/website/src/examples/event-handlers/EventHandlersExample.tsx
@@ -1,7 +1,6 @@
 import {MouseEvent, useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {Subject} from 'rxjs'
-import {map, startWith} from 'rxjs/operators'
+import {map, startWith, Subject} from 'rxjs'
 
 // Create subject for mouse moves
 const mouseMove$ = new Subject<MouseEvent>()

--- a/website/src/examples/fetch/FetchExample.tsx
+++ b/website/src/examples/fetch/FetchExample.tsx
@@ -3,13 +3,13 @@ import {
   useObservable,
   useObservableEvent,
 } from 'react-rx'
-import {Subject} from 'rxjs'
 import {
   distinctUntilChanged,
   map,
+  Subject,
   switchMap,
   tap,
-} from 'rxjs/operators'
+} from 'rxjs'
 
 // Create subject for URL changes
 const url$ = new Subject<string>()

--- a/website/src/examples/fizz-buzz/FizzBuzzExample.tsx
+++ b/website/src/examples/fizz-buzz/FizzBuzzExample.tsx
@@ -1,6 +1,5 @@
 import {useObservable} from 'react-rx'
-import {timer} from 'rxjs'
-import {map, take} from 'rxjs/operators'
+import {map, take, timer} from 'rxjs'
 
 const observable = timer(0, 500).pipe(
   map((n) => n + 1),

--- a/website/src/examples/form-data/FormDataExample.tsx
+++ b/website/src/examples/form-data/FormDataExample.tsx
@@ -7,15 +7,16 @@ import {
   useObservable,
   useObservableEvent,
 } from 'react-rx'
-import {type Observable, Subject} from 'rxjs'
 import {
+  type Observable,
   map,
   scan,
   startWith,
+  Subject,
   switchMap,
   tap,
   withLatestFrom,
-} from 'rxjs/operators'
+} from 'rxjs'
 import {styled} from 'styled-components'
 
 import storage from './storage'

--- a/website/src/examples/reactive-state/ReactiveStateExample.tsx
+++ b/website/src/examples/reactive-state/ReactiveStateExample.tsx
@@ -1,7 +1,6 @@
 import {useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
-import {timer} from 'rxjs'
-import {map, startWith} from 'rxjs/operators'
+import {map, startWith, timer} from 'rxjs'
 
 export default function App() {
   const [delay, setDelay] = useState(500)

--- a/website/src/examples/search/SearchExample.tsx
+++ b/website/src/examples/search/SearchExample.tsx
@@ -7,15 +7,16 @@ import {
   useObservable,
   useObservableEvent,
 } from 'react-rx'
-import {Observable, Subject} from 'rxjs'
-import {timer} from 'rxjs'
 import {
   distinctUntilChanged,
   filter,
   map,
+  Observable,
+  Subject,
   switchMap,
   tap,
-} from 'rxjs/operators'
+  timer,
+} from 'rxjs'
 
 interface SearchResult {
   keyword: string

--- a/website/src/examples/tick/Ticker.tsx
+++ b/website/src/examples/tick/Ticker.tsx
@@ -1,12 +1,13 @@
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {type Observable, timer} from 'rxjs'
 import {
   distinctUntilChanged,
   map,
+  type Observable,
   startWith,
   switchMap,
-} from 'rxjs/operators'
+  timer,
+} from 'rxjs'
 
 export function Ticker(props: {
   observable: Observable<number>

--- a/website/src/examples/tick/TickerWithSubTick.tsx
+++ b/website/src/examples/tick/TickerWithSubTick.tsx
@@ -1,12 +1,13 @@
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
-import {type Observable, timer} from 'rxjs'
 import {
   distinctUntilChanged,
   map,
+  type Observable,
   sampleTime,
   switchMap,
-} from 'rxjs/operators'
+  timer,
+} from 'rxjs'
 
 const initial = {tick: 0, subtick: 0} as const
 

--- a/website/src/examples/todo-app/TodoApp.example.tsx
+++ b/website/src/examples/todo-app/TodoApp.example.tsx
@@ -7,15 +7,15 @@ import {
   useObservable,
   useObservableEvent,
 } from 'react-rx'
-import {Subject} from 'rxjs'
 import {
   filter,
   map,
   scan,
   startWith,
+  Subject,
   tap,
   withLatestFrom,
-} from 'rxjs/operators'
+} from 'rxjs'
 import {styled} from 'styled-components'
 
 interface TodoItem {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Consolidate all operator imports onto `'rxjs'` (library, docs, examples, agent skill snippets), dropping the deprecated `'rxjs/operators'` path.
- Tighten the `rxjs` peer dependency from `^7` to `^7.2`, which is when operators became available on the main export. The library already imported operators like `catchError` / `share` / `finalize` from `'rxjs'`, so this matches the real requirement.
- Document the React `^19.2` and RxJS `^7.2` requirements in the README, with a link to the [RxJS import migration guide](https://rxjs.dev/guide/importing#how-to-migrate) for apps still on older RxJS.

## Why `^7.2`

RxJS 7.2 moved (almost all) operators to the main `'rxjs'` entry point and deprecated `'rxjs/operators'`. Named imports from `'rxjs'` are the recommended tree-shake-friendly style going forward.

## Verification

- `pnpm lint` — pass
- `pnpm test` — pass (48 tests)
- `pnpm build` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce2f6ea9-232f-45c2-9558-d48fb469c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce2f6ea9-232f-45c2-9558-d48fb469c3ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

