### PR TITLE
docs: clarify useObservable disabled is pause, not zero-subscribe

### DIFF
--- a/.changeset/clarify-disabled-option.md
+++ b/.changeset/clarify-disabled-option.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Clarify that `useObservable`'s `disabled` option pauses the live store subscription (and keeps returning the last value) but does not skip the render-phase warm-up subscription. Document swapping the observable when zero subscriptions are required.

--- a/.changeset/use-observable-disabled-no-subscribe.md
+++ b/.changeset/use-observable-disabled-no-subscribe.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Honor the `disabled` option on `useObservable`: when `disabled: true`, the hook no longer performs its eager render-phase subscription (previously it still subscribed once during render, contradicting the documented contract). Subscription starts only once `disabled` becomes `false`.

--- a/.changeset/use-observable-disabled-no-subscribe.md
+++ b/.changeset/use-observable-disabled-no-subscribe.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Honor the `disabled` option on `useObservable`: when `disabled: true`, the hook no longer performs its eager render-phase subscription (previously it still subscribed once during render, contradicting the documented contract). Subscription starts only once `disabled` becomes `false`.

--- a/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
@@ -14,8 +14,9 @@ import {useObservable} from '../useObservable'
  * that terminate (complete or error) synchronously upon subscription, `finalize` fired during that eager
  * subscription — while the entry was not yet in the cache — so the delete was a no-op and the entry was
  * inserted right after, with nothing left to evict it. A later committed mount would re-trigger teardown
- * through its store subscription and clean the entry up, but that never happens for server renders or
- * renders that throw before commit (synchronously erroring sources). In those cases the entry retained
+ * through its store subscription and clean the entry up, but that never happens for server renders,
+ * disabled hooks (which still warm up via the eager subscribe, but never establish a store subscription),
+ * or renders that throw before commit (synchronously erroring sources). In those cases the entry retained
  * the last snapshot/error for as long as the source observable object itself stayed alive, and a
  * poisoned entry replayed its stale error on later mounts instead of re-subscribing.
  */
@@ -39,37 +40,29 @@ async function forceGC() {
   }
 }
 
-test('does not subscribe to a synchronously completing observable while disabled', async () => {
-  let subscriptions = 0
+test('releases the last snapshot of a synchronously completing observable used by a disabled hook', async () => {
   let snapshotRef: WeakRef<object> | undefined
   // Long-lived source, as if declared at module scope in an app. It emits a fresh object per
   // subscription and completes synchronously (like a replayed+completed cache observable would).
   const source = defer(() => {
-    subscriptions++
     const snapshot = {payload: 'x'.repeat(1024)}
     snapshotRef = new WeakRef(snapshot)
     return of(snapshot)
   })
 
-  function ObservableComponent({disabled}: {disabled: boolean}) {
-    useObservable(source, undefined, {disabled})
+  function ObservableComponent() {
+    useObservable(source, undefined, {disabled: true})
     return null
   }
 
-  const {unmount, rerender} = render(<ObservableComponent disabled={true} />)
-
-  // Disabled hooks must not subscribe at all — not even the eager render-phase subscribe — so the
-  // source factory never runs and no snapshot is retained.
-  expect(subscriptions).toBe(0)
-  expect(snapshotRef).toBeUndefined()
-
-  rerender(<ObservableComponent disabled={false} />)
-  expect(subscriptions).toBeGreaterThan(0)
-  expect(snapshotRef!.deref()).toEqual({payload: 'x'.repeat(1024)})
-
+  const {unmount} = render(<ObservableComponent />)
   unmount()
+
   await forceGC()
 
+  // While disabled, the hook still performs its eager render-phase warm-up subscription (disabled only
+  // pauses the live store subscription), but nothing re-triggers teardown after that — so the entry
+  // created during render must already have been evicted, releasing the snapshot.
   expect(snapshotRef!.deref()).toBeUndefined()
   // Keep the source — the WeakMap key — strongly reachable across the GC above, so the snapshot can
   // only have been released through eviction, not by the key getting collected.

--- a/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
@@ -14,10 +14,10 @@ import {useObservable} from '../useObservable'
  * that terminate (complete or error) synchronously upon subscription, `finalize` fired during that eager
  * subscription — while the entry was not yet in the cache — so the delete was a no-op and the entry was
  * inserted right after, with nothing left to evict it. A later committed mount would re-trigger teardown
- * through its store subscription and clean the entry up, but that never happens for server renders,
- * disabled hooks, or renders that throw before commit (synchronously erroring sources). In those cases
- * the entry retained the last snapshot/error for as long as the source observable object itself stayed
- * alive, and a poisoned entry replayed its stale error on later mounts instead of re-subscribing.
+ * through its store subscription and clean the entry up, but that never happens for server renders or
+ * renders that throw before commit (synchronously erroring sources). In those cases the entry retained
+ * the last snapshot/error for as long as the source observable object itself stayed alive, and a
+ * poisoned entry replayed its stale error on later mounts instead of re-subscribing.
  */
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -40,31 +40,38 @@ async function forceGC() {
 }
 
 test(
-  'releases the last snapshot of a synchronously completing observable used by a disabled hook',
+  'does not subscribe to a synchronously completing observable while disabled',
   async () => {
+    let subscriptions = 0
     let snapshotRef: WeakRef<object> | undefined
     // Long-lived source, as if declared at module scope in an app. It emits a fresh object per
     // subscription and completes synchronously (like a replayed+completed cache observable would).
     const source = defer(() => {
+      subscriptions++
       const snapshot = {payload: 'x'.repeat(1024)}
       snapshotRef = new WeakRef(snapshot)
       return of(snapshot)
     })
 
-    function ObservableComponent() {
-      useObservable(source, undefined, {disabled: true})
+    function ObservableComponent({disabled}: {disabled: boolean}) {
+      useObservable(source, undefined, {disabled})
       return null
     }
 
-    const {unmount} = render(<ObservableComponent />)
-    unmount()
+    const {unmount, rerender} = render(<ObservableComponent disabled={true} />)
 
+    // Disabled hooks must not subscribe at all — not even the eager render-phase subscribe — so the
+    // source factory never runs and no snapshot is retained.
+    expect(subscriptions).toBe(0)
+    expect(snapshotRef).toBeUndefined()
+
+    rerender(<ObservableComponent disabled={false} />)
+    expect(subscriptions).toBeGreaterThan(0)
+    expect(snapshotRef!.deref()).toEqual({payload: 'x'.repeat(1024)})
+
+    unmount()
     await forceGC()
 
-    // While disabled, the hook never establishes its store subscription — only the eager render-phase
-    // subscription runs (that a disabled hook subscribes at all contradicts the documented `disabled`
-    // contract and is left for a follow-up). With no store subscription to re-trigger teardown, the
-    // entry created during render must already have been evicted, releasing the snapshot.
     expect(snapshotRef!.deref()).toBeUndefined()
     // Keep the source — the WeakMap key — strongly reachable across the GC above, so the snapshot can
     // only have been released through eviction, not by the key getting collected.

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -320,11 +320,58 @@ test('should throw during SSR if no initial value is defined', () => {
 })
 
 test('should not subscribe if the disabled prop is present', () => {
-  const values$ = new Subject<string | undefined>()
+  let subscriptions = 0
+  const values$ = new Observable<string>((subscriber) => {
+    subscriptions++
+    subscriber.next('emitted')
+  })
+
   const {result, unmount} = renderHook(() => useObservable(values$, 'initial', {disabled: true}))
 
-  act(() => values$.next('something'))
+  expect(subscriptions).toBe(0)
   expect(result.current).toBe('initial')
+
+  unmount()
+  expect(subscriptions).toBe(0)
+})
+
+test('should not subscribe to a synchronously emitting observable while disabled', () => {
+  let subscriptions = 0
+  const values$ = of('sync').pipe(
+    map((value) => {
+      subscriptions++
+      return value
+    }),
+  )
+
+  // `of(...)` completes synchronously on subscribe — without the disabled guard the eager
+  // render-phase subscription would still run and both subscribe and resolve past initialValue.
+  const {result, unmount} = renderHook(() => useObservable(values$, 'initial', {disabled: true}))
+
+  expect(subscriptions).toBe(0)
+  expect(result.current).toBe('initial')
+
+  unmount()
+})
+
+test('should subscribe when disabled flips from true to false', () => {
+  let subscriptions = 0
+  const values$ = new Observable<string>((subscriber) => {
+    subscriptions++
+    subscriber.next('live')
+  })
+
+  const {result, unmount, rerender} = renderHook<string, UseObservableOptions>(
+    (props) => useObservable(values$, 'initial', props),
+    {initialProps: {disabled: true}},
+  )
+
+  expect(subscriptions).toBe(0)
+  expect(result.current).toBe('initial')
+
+  rerender({disabled: false})
+  expect(subscriptions).toBeGreaterThan(0)
+  expect(result.current).toBe('live')
 
   unmount()
 })

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -319,59 +319,12 @@ test('should throw during SSR if no initial value is defined', () => {
   )
 })
 
-test('should not subscribe if the disabled prop is present', () => {
-  let subscriptions = 0
-  const values$ = new Observable<string>((subscriber) => {
-    subscriptions++
-    subscriber.next('emitted')
-  })
-
+test('should not receive updates while disabled', () => {
+  const values$ = new Subject<string | undefined>()
   const {result, unmount} = renderHook(() => useObservable(values$, 'initial', {disabled: true}))
 
-  expect(subscriptions).toBe(0)
+  act(() => values$.next('something'))
   expect(result.current).toBe('initial')
-
-  unmount()
-  expect(subscriptions).toBe(0)
-})
-
-test('should not subscribe to a synchronously emitting observable while disabled', () => {
-  let subscriptions = 0
-  const values$ = of('sync').pipe(
-    map((value) => {
-      subscriptions++
-      return value
-    }),
-  )
-
-  // `of(...)` completes synchronously on subscribe — without the disabled guard the eager
-  // render-phase subscription would still run and both subscribe and resolve past initialValue.
-  const {result, unmount} = renderHook(() => useObservable(values$, 'initial', {disabled: true}))
-
-  expect(subscriptions).toBe(0)
-  expect(result.current).toBe('initial')
-
-  unmount()
-})
-
-test('should subscribe when disabled flips from true to false', () => {
-  let subscriptions = 0
-  const values$ = new Observable<string>((subscriber) => {
-    subscriptions++
-    subscriber.next('live')
-  })
-
-  const {result, unmount, rerender} = renderHook<string, UseObservableOptions>(
-    (props) => useObservable(values$, 'initial', props),
-    {initialProps: {disabled: true}},
-  )
-
-  expect(subscriptions).toBe(0)
-  expect(result.current).toBe('initial')
-
-  rerender({disabled: false})
-  expect(subscriptions).toBeGreaterThan(0)
-  expect(result.current).toBe('live')
 
   unmount()
 })

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -40,6 +40,11 @@ const EMPTY_OBJECT = {}
 
 /** @public */
 export interface UseObservableOptions {
+  /**
+   * Pause the active store subscription. While `true`, later emissions do not update the component
+   * and the last received value (or `initialValue`) is returned. Does not skip the render-phase
+   * warm-up subscription — swap the observable if you need zero subscriptions.
+   */
   disabled?: boolean
 }
 
@@ -110,31 +115,23 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
       },
     }
 
-    // The entry must be added to the cache before any subscription: if the observable terminates
-    // synchronously during subscribe, `finalize` runs right away and must find the entry in order to
+    // The entry must be added to the cache before the eager subscription below: if the observable
+    // terminates synchronously during it, `finalize` runs right away and must find the entry in order to
     // delete it. Inserting the entry afterwards would retain it (and its last snapshot or error) for as
     // long as the source observable lives, and poisoned entries would replay stale errors on remount
     // instead of re-subscribing the source.
     cache.set(observable, entry)
 
-    // For synchronously terminating observables the entry may already have been evicted again by the
-    // time a later subscribe finishes, so return the local reference instead of reading back from the
-    // cache.
+    // Eagerly subscribe during render to warm up a synchronous snapshot into `state`. This runs even
+    // when `disabled` is true — `disabled` only pauses the live store subscription below. The
+    // subscribe/unsubscribe here does not keep the observable alive; the store subscription does.
+    const subscription = entry.observable.subscribe()
+    subscription.unsubscribe()
+
+    // For synchronously terminating observables the entry has already been evicted from the cache again
+    // at this point, so return the local reference instead of reading back from the cache.
     return entry
   }, [observable])
-
-  // Eagerly subscribe during render so a synchronous emission is available to `getSnapshot` in the
-  // same pass. Skip while `disabled` — the documented contract is that the hook must not subscribe
-  // until/unless it becomes enabled. Re-running when `disabled` flips to `false` primes the snapshot
-  // then. The memo returns `instance` so the result is used (and so disabled toggles keep the same
-  // cache entry, preserving the last snapshot after an enabled→disabled transition).
-  const store = useMemo(() => {
-    if (!disabled) {
-      const subscription = instance.observable.subscribe()
-      subscription.unsubscribe()
-    }
-    return instance
-  }, [instance, disabled])
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -142,18 +139,18 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
         return () => {}
       }
 
-      const subscription = store.observable.subscribe(onStoreChange)
+      const subscription = instance.observable.subscribe(onStoreChange)
       return () => {
         subscription.unsubscribe()
       }
     },
-    [store.observable, disabled],
+    [instance.observable, disabled],
   )
 
   return useSyncExternalStore<ObservedValueOf<ObservableType>>(
     subscribe,
     () => {
-      return store.getSnapshot(initialValue)
+      return instance.getSnapshot(initialValue)
     },
     typeof initialValue === 'undefined'
       ? undefined

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -110,21 +110,31 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
       },
     }
 
-    // The entry must be added to the cache before the eager subscription below: if the observable
-    // terminates synchronously during it, `finalize` runs right away and must find the entry in order to
+    // The entry must be added to the cache before any subscription: if the observable terminates
+    // synchronously during subscribe, `finalize` runs right away and must find the entry in order to
     // delete it. Inserting the entry afterwards would retain it (and its last snapshot or error) for as
     // long as the source observable lives, and poisoned entries would replay stale errors on remount
     // instead of re-subscribing the source.
     cache.set(observable, entry)
 
-    // Eagerly subscribe to sync set `state.snapshot` to what the observable returns, and keep the observable alive until the component unmounts.
-    const subscription = entry.observable.subscribe()
-    subscription.unsubscribe()
-
-    // For synchronously terminating observables the entry has already been evicted from the cache again
-    // at this point, so return the local reference instead of reading back from the cache.
+    // For synchronously terminating observables the entry may already have been evicted again by the
+    // time a later subscribe finishes, so return the local reference instead of reading back from the
+    // cache.
     return entry
   }, [observable])
+
+  // Eagerly subscribe during render so a synchronous emission is available to `getSnapshot` in the
+  // same pass. Skip while `disabled` — the documented contract is that the hook must not subscribe
+  // until/unless it becomes enabled. Re-running when `disabled` flips to `false` primes the snapshot
+  // then. The memo returns `instance` so the result is used (and so disabled toggles keep the same
+  // cache entry, preserving the last snapshot after an enabled→disabled transition).
+  const store = useMemo(() => {
+    if (!disabled) {
+      const subscription = instance.observable.subscribe()
+      subscription.unsubscribe()
+    }
+    return instance
+  }, [instance, disabled])
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -132,18 +142,18 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
         return () => {}
       }
 
-      const subscription = instance.observable.subscribe(onStoreChange)
+      const subscription = store.observable.subscribe(onStoreChange)
       return () => {
         subscription.unsubscribe()
       }
     },
-    [instance.observable, disabled],
+    [store.observable, disabled],
   )
 
   return useSyncExternalStore<ObservedValueOf<ObservableType>>(
     subscribe,
     () => {
-      return instance.getSnapshot(initialValue)
+      return store.getSnapshot(initialValue)
     },
     typeof initialValue === 'undefined'
       ? undefined

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -45,15 +45,17 @@ function MyComponent(props) {
 }
 ```
 
-The `disabled` option is optional. If its omitted, the hook will subscribe to the observable and return the current value. If its `true` initially, the hook will not subscribe to the observable and return the `initialValue` if provided. In the event that it has already subscribed it will then unsubscribe from the observable and return the last value it received.
+The `disabled` option pauses the hook's *active* subscription — think of it like `pause: true`. While `disabled` is `true`, the hook will not keep a live subscription that pushes updates into the component, and it returns the last value it already received (or the `initialValue` if nothing has been received yet). Turning `disabled` back to `false` resumes the live subscription.
+
+Important: `disabled` does **not** skip the hook's initial warm-up subscription. `useObservable` always briefly subscribes during render so a synchronous emission can become the current snapshot. That means cold observables with subscribe-time side effects (for example `fromFetch`) still run that work even when `disabled` is `true`.
 
 ```tsx
 import {useEffect, useState} from 'react'
 import {useObservable} from 'react-rx'
 import {Subject} from 'rxjs'
 
-// This component will never render "Hello world!" while `disabled` is true,
-// even if the subject emits asynchronously.
+// While `disabled` is true, later async emissions are ignored and the last
+// received value (here the initialValue "mars") is returned.
 function MyComponent(props) {
   const [observable] = useState(() => new Subject<string>())
   const planet = useObservable(observable, 'mars', {disabled: true})
@@ -65,6 +67,35 @@ function MyComponent(props) {
   return <>Hello {planet}!</>
 }
 ```
+
+If the goal is to avoid *any* subscription to a particular observable, do not use `disabled`. Pass a different observable instead — for example swap in `of(null)` until you are ready to fetch:
+
+```tsx
+import {useMemo} from 'react'
+import {useObservable} from 'react-rx'
+import {of} from 'rxjs'
+import {fromFetch} from 'rxjs/fetch'
+
+function Users({shouldFetch}: {shouldFetch: boolean}) {
+  // Prefer swapping the observable over `{disabled: !shouldFetch}`:
+  // `disabled` still performs the render-phase warm-up subscribe, which would
+  // fire the request even when `shouldFetch` is false.
+  const users$ = useMemo(
+    () =>
+      shouldFetch
+        ? fromFetch('https://api.github.com/users?per_page=5', {
+            selector: (response) => response.json(),
+          })
+        : of(null),
+    [shouldFetch],
+  )
+  const users = useObservable(users$, null)
+
+  return <pre>{JSON.stringify(users, null, 2)}</pre>
+}
+```
+
+Because the fetch observable is only created (and therefore only ever subscribed) when `shouldFetch` is true, this guarantees zero subscriptions to `fromFetch` until then.
 
 ### useObservableEvent()
 

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -19,6 +19,8 @@ interface UseObservableOptions {
 }
 ```
 
+`disabled` pauses the live subscription (later emissions stop updating the component; the last value is kept). It does **not** skip the render-phase warm-up subscription — see the [guide](/guide) for swapping the observable when you need zero subscriptions.
+
 **Example**
 
 ```tsx


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #451, but **docs only** — no behavior change.

`disabled: true` was documented as “will not subscribe,” which was wrong. It only pauses the live `useSyncExternalStore` subscription (no further updates; last value kept). The render-phase warm-up subscribe still runs, so cold observables with subscribe-time side effects (e.g. `fromFetch`) still fire.

## Docs

- Guide: describe `disabled` as pause-like; note the warm-up subscribe; show swapping the observable (`shouldFetch ? fromFetch(...) : of(null)` in `useMemo`) when zero subscriptions are required
- API reference + `UseObservableOptions` JSDoc: same clarification
- Leak / disabled tests: comments and naming aligned with pause semantics (eager warm-up is intentional)

## Test plan

- [x] `pnpm test` — 78 passed
- [x] `pnpm lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bab6065-c899-470c-bfe2-77e90f1c0d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bab6065-c899-470c-bfe2-77e90f1c0d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

