### PR TITLE
feat!: defer useObservable updates; add useSyncObservable

### DIFF
--- a/.changeset/deferred-use-observable.md
+++ b/.changeset/deferred-use-observable.md
@@ -1,0 +1,9 @@
+---
+"react-rx": major
+---
+
+**BREAKING:** `useObservable` now defers store updates with `useDeferredValue` — urgent renders keep the previous value while a background render catches up. Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash). SSR now renders exactly what the first client render would show (synchronous emissions win over the `initialValue`) and no longer throws when `initialValue` is omitted; synchronously erroring observables now fail the server render instead of masking the error until hydration.
+
+New `useSyncObservable` preserves the exact v4 synchronous behavior, including the strict `getServerSnapshot` contract — switch to it for values feeding controlled inputs or strict server markup control (or rename wholesale for a mechanical migration).
+
+See the [v4 to v5 migration guide](https://react-rx.dev/migrate/v4-to-v5).

--- a/packages/react-rx/README.md
+++ b/packages/react-rx/README.md
@@ -7,6 +7,7 @@
 Features:
 
 - Works well with Observables emitting values synchronously. You don't pay the re-render-on-mount tax.
+- Non-blocking by default — `useObservable` defers store updates; reach for `useSyncObservable` for controlled inputs.
 - Lightweight. Implemented on top of a small React Hook based core.
 - Full TypeScript support.
 
@@ -21,6 +22,7 @@ This package provides React hooks for working with RxJS Observables in your comp
 
 - [Guide](https://react-rx.dev/guide)
 - [API reference](https://react-rx.dev/reference)
+- [Migration (v4 → v5)](https://react-rx.dev/migrate/v4-to-v5)
 - [Code examples](https://react-rx.dev/examples/simple)
 
 ---

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -62,7 +62,6 @@
     }
   },
   "scripts": {
-    "prepare": "pnpm build",
     "build": "tsdown",
     "prepublishOnly": "pnpm build",
     "test": "vitest run --typecheck",

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -62,6 +62,7 @@
     }
   },
   "scripts": {
+    "prepare": "pnpm build",
     "build": "tsdown",
     "prepublishOnly": "pnpm build",
     "test": "vitest run --typecheck",

--- a/packages/react-rx/src/__tests__/errors.test.tsx
+++ b/packages/react-rx/src/__tests__/errors.test.tsx
@@ -1,36 +1,49 @@
 import {render} from '@testing-library/react'
 import {mergeMap, of, Subject, throwError} from 'rxjs'
-import {expect, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 
 import {useObservable} from '../useObservable.ts'
+import {useSyncObservable} from '../useSyncObservable.ts'
 
-test('errors emitted by the observable should be thrown during the react render phase', () => {
-  const subject = new Subject<{error: boolean; message: string}>()
+const hooks = [
+  {name: 'useObservable', useHook: useObservable},
+  {name: 'useSyncObservable', useHook: useSyncObservable},
+] as const
 
-  const messages = subject
-    .asObservable()
-    .pipe(
-      mergeMap((value) =>
-        value.error ? throwError(() => new Error(value.message)) : of(value.message),
-      ),
-    )
+describe.each(hooks)(
+  '$name: errors emitted by the observable should be thrown during the react render phase',
+  ({useHook}) => {
+    test('throws during render after an error emission', () => {
+      // For useObservable the uSES getSnapshot call throws during the urgent render,
+      // before the useDeferredValue line executes.
+      const subject = new Subject<{error: boolean; message: string}>()
 
-  function ObservableComponent() {
-    return useObservable(messages, '☺️')
-  }
+      const messages = subject
+        .asObservable()
+        .pipe(
+          mergeMap((value) =>
+            value.error ? throwError(() => new Error(value.message)) : of(value.message),
+          ),
+        )
 
-  const {container, rerender} = render(<ObservableComponent />)
-  // no error (yet)
-  expect(container).toMatchInlineSnapshot(`
-    <div>
-      ☺️
-    </div>
-  `)
+      function ObservableComponent() {
+        return useHook(messages, '☺️')
+      }
 
-  // Note that the error is thrown later, during the render phase
-  subject.next({error: true, message: 'Boom'})
+      const {container, rerender} = render(<ObservableComponent />)
+      // no error (yet)
+      expect(container).toMatchInlineSnapshot(`
+        <div>
+          ☺️
+        </div>
+      `)
 
-  expect(() => rerender(<ObservableComponent />)).toThrowErrorMatchingInlineSnapshot(
-    `[Error: Boom]`,
-  )
-})
+      // Note that the error is thrown later, during the render phase
+      subject.next({error: true, message: 'Boom'})
+
+      expect(() => rerender(<ObservableComponent />)).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Boom]`,
+      )
+    })
+  },
+)

--- a/packages/react-rx/src/__tests__/strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/strictmode.test.tsx
@@ -1,85 +1,101 @@
 import {act, render} from '@testing-library/react'
 import {useEffect, useMemo} from 'react'
 import {BehaviorSubject, Observable} from 'rxjs'
-import {expect, test} from 'vitest'
+import {describe, expect, test} from 'vitest'
 
 import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-test('Strict mode should trigger double mount effects and re-renders', async () => {
-  const subject = new BehaviorSubject(0)
-  const observable = subject.asObservable()
+const hooks = [
+  {name: 'useSyncObservable', useHook: useSyncObservable},
+  {name: 'useObservable', useHook: useObservable},
+] as const
 
-  const returnedValues: unknown[] = []
-  let mountCount = 0
-  function ObservableComponent() {
-    useEffect(() => {
-      mountCount++
-    }, [])
-    const observedValue = useObservable(observable)
-    returnedValues.push(observedValue)
-    return <>{observedValue}</>
-  }
+describe.each(hooks)('$name', ({useHook}) => {
+  test('Strict mode should trigger double mount effects and re-renders', async () => {
+    const subject = new BehaviorSubject(0)
+    const observable = subject.asObservable()
 
-  render(<ObservableComponent />, {reactStrictMode: true})
-  expect(mountCount).toEqual(2)
-
-  expect(returnedValues).toEqual([0, 0])
-
-  await wait(10)
-  act(() => subject.next(1))
-  expect(returnedValues).toEqual([0, 0, 1, 1])
-
-  act(() => subject.next(2))
-  expect(returnedValues).toEqual([0, 0, 1, 1, 2, 2])
-
-  expect(mountCount).toEqual(2)
-})
-
-test('Strict mode should unsubscribe the source observable on unmount', async () => {
-  const subscribed: number[] = []
-  const unsubscribed: number[] = []
-  let nextId = 0
-  const observable = new Observable(() => {
-    const id = nextId++
-    subscribed.push(id)
-    return () => {
-      unsubscribed.push(id)
+    const returnedValues: unknown[] = []
+    let mountCount = 0
+    function ObservableComponent() {
+      useEffect(() => {
+        mountCount++
+      }, [])
+      const observedValue = useHook(observable)
+      returnedValues.push(observedValue)
+      return <>{observedValue}</>
     }
+
+    render(<ObservableComponent />, {reactStrictMode: true})
+    expect(mountCount).toEqual(2)
+
+    // useObservable may schedule an Object.is bail-out deferred pass on mount
+    // (useDeferredValue second arg is defined), so mount can produce more than two
+    // Strict Mode renders — all must still be the sync BehaviorSubject value.
+    expect(returnedValues.length).toBeGreaterThanOrEqual(2)
+    expect(returnedValues.every((v) => v === 0)).toBe(true)
+    const afterMount = returnedValues.length
+
+    await wait(10)
+    act(() => subject.next(1))
+    expect(returnedValues.slice(afterMount).at(-1)).toBe(1)
+    expect(returnedValues.slice(afterMount)).toContain(1)
+
+    const afterOne = returnedValues.length
+    act(() => subject.next(2))
+    expect(returnedValues.slice(afterOne).at(-1)).toBe(2)
+    expect(returnedValues.slice(afterOne)).toContain(2)
+
+    expect(mountCount).toEqual(2)
   })
 
-  function ObservableComponent() {
-    useObservable(observable)
-    return null
-  }
-
-  const {unmount} = render(<ObservableComponent />, {reactStrictMode: true})
-  expect(subscribed).toEqual([0])
-  unmount()
-  await Promise.resolve()
-  expect(unsubscribed).toEqual([0])
-})
-
-test('Strict mode should unsubscribe the source observable on unmount if its created in a useMemo', async () => {
-  let subscriberCount: number = 0
-  const getObservable = () =>
-    new Observable(() => {
-      subscriberCount++
+  test('Strict mode should unsubscribe the source observable on unmount', async () => {
+    const subscribed: number[] = []
+    const unsubscribed: number[] = []
+    let nextId = 0
+    const observable = new Observable(() => {
+      const id = nextId++
+      subscribed.push(id)
       return () => {
-        subscriberCount--
+        unsubscribed.push(id)
       }
     })
 
-  function ObservableComponent() {
-    const memoObservable = useMemo(() => getObservable(), [])
-    useObservable(memoObservable)
-    return null
-  }
+    function ObservableComponent() {
+      useHook(observable)
+      return null
+    }
 
-  const {unmount} = render(<ObservableComponent />, {reactStrictMode: true})
-  expect(subscriberCount, 'Subscriber count should be 1').toBe(1)
-  unmount()
-  await Promise.resolve()
-  expect(subscriberCount, 'Subscriber count should be 0').toBe(0)
+    const {unmount} = render(<ObservableComponent />, {reactStrictMode: true})
+    expect(subscribed).toEqual([0])
+    unmount()
+    await Promise.resolve()
+    expect(unsubscribed).toEqual([0])
+  })
+
+  test('Strict mode should unsubscribe the source observable on unmount if its created in a useMemo', async () => {
+    let subscriberCount: number = 0
+    const getObservable = () =>
+      new Observable(() => {
+        subscriberCount++
+        return () => {
+          subscriberCount--
+        }
+      })
+
+    function ObservableComponent() {
+      const memoObservable = useMemo(() => getObservable(), [])
+      useHook(memoObservable)
+      return null
+    }
+
+    const {unmount} = render(<ObservableComponent />, {reactStrictMode: true})
+    expect(subscriberCount, 'Subscriber count should be 1').toBe(1)
+    unmount()
+    await Promise.resolve()
+    expect(subscriberCount, 'Subscriber count should be 0').toBe(0)
+  })
 })

--- a/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
@@ -490,3 +490,86 @@ test('after async emission, hiding Activity then updating parent state: last emi
   expect(textOf('value')).toBe('async-emitted')
   expect(screen.getByTestId('child').style.display).not.toBe('none')
 })
+
+/** Used by the no-flash scenario below — kept at module scope so identity is stable across re-renders. */
+function NoFlashProbe({
+  label,
+  observable,
+  log,
+}: {
+  label: string
+  observable: Observable<string>
+  log: string[]
+}) {
+  const value = useObservable(observable, 'initial')
+  log.push(value)
+  return (
+    <div data-testid="value">
+      {label}:{value}
+    </div>
+  )
+}
+
+function NoFlashApp({observable, log}: {observable: Observable<string>; log: string[]}) {
+  const [mode, setMode] = useState<'visible' | 'hidden'>('visible')
+  const [label, setLabel] = useState('a')
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setMode((m) => (m === 'visible' ? 'hidden' : 'visible'))}
+      >
+        toggle
+      </button>
+      <button type="button" onClick={() => setLabel('b')}>
+        relabel
+      </button>
+      <Activity mode={mode}>
+        <NoFlashProbe label={label} observable={observable} log={log} />
+      </Activity>
+    </>
+  )
+}
+
+test('hidden re-renders and the reveal never render the initialValue (no flash)', async () => {
+  // Renders inside a hidden Activity take useDeferredValue's *mount* path, which returns the
+  // second argument. Because that argument is the live snapshot (not the initialValue), a
+  // hidden re-render — and therefore the later reveal — never shows the initialValue.
+  // (A clean reveal with no intervening update restores the preserved tree without
+  // re-rendering at all, so this test forces a parent update while hidden.)
+  const subject = new Subject<string>()
+  const log: string[] = []
+
+  render(<NoFlashApp observable={subject} log={log} />)
+  act(() => subject.next('emitted'))
+  expect(textOf('value')).toBe('a:emitted')
+
+  // Hide: the store subscription tears down but the WeakMap cache entry survives.
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+  await Promise.resolve()
+  expect(screen.getByTestId('value').style.display).toBe('none')
+
+  log.length = 0
+  // Parent update re-renders the hidden tree (lower priority — give React a turn to flush).
+  await act(async () => {
+    screen.getByRole('button', {name: 'relabel'}).click()
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  expect(log.length).toBeGreaterThan(0)
+  expect(log).not.toContain('initial')
+  expect(textOf('value')).toBe('b:emitted')
+
+  // Reveal: the preserved tree still shows the cached snapshot.
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+  await Promise.resolve()
+  expect(textOf('value')).toBe('b:emitted')
+  expect(screen.getByTestId('value').style.display).not.toBe('none')
+  expect(log).not.toContain('initial')
+  expect(log.every((v) => v === 'emitted')).toBe(true)
+})

--- a/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
@@ -44,9 +44,7 @@ function SuspendOn({value}: {value: string}) {
 }
 
 function withSuspense(child: ReactNode) {
-  return (
-    <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
-  )
+  return <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
 }
 
 let container: HTMLDivElement | undefined

--- a/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
@@ -3,7 +3,7 @@ import {Suspense, type ReactNode} from 'react'
 import {hydrateRoot} from 'react-dom/client'
 import {renderToString} from 'react-dom/server'
 import {map, Observable, of, Subject, timer} from 'rxjs'
-import {afterEach, expect, test, vi} from 'vitest'
+import {afterEach, expect, test, vi, type MockInstance} from 'vitest'
 
 import {useObservable} from '../useObservable'
 import {useSyncObservable} from '../useSyncObservable'
@@ -50,15 +50,16 @@ function withSuspense(child: ReactNode) {
 }
 
 let container: HTMLDivElement | undefined
-let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined
+let consoleErrorSpy: MockInstance<(...data: unknown[]) => void> | undefined
 const roots: Array<ReturnType<typeof hydrateRoot>> = []
 
 afterEach(async () => {
-  for (const root of roots.splice(0)) {
-    await act(async () => {
+  const toUnmount = roots.splice(0)
+  await act(async () => {
+    for (const root of toUnmount) {
       root.unmount()
-    })
-  }
+    }
+  })
   container?.remove()
   container = undefined
   consoleErrorSpy?.mockRestore()
@@ -81,8 +82,8 @@ async function hydrate(ui: ReactNode, html: string) {
 
 function hydrationErrors() {
   return (consoleErrorSpy?.mock.calls ?? [])
-    .map((args) => String(args[0]))
-    .filter((msg) => /hydrat|did not match|Text content does not match/i.test(msg))
+    .map((args: unknown[]) => String(args[0]))
+    .filter((msg: string) => /hydrat|did not match|Text content does not match/i.test(msg))
 }
 
 test('hydration is clean for both hooks when the observable has not emitted (initialValue everywhere)', async () => {

--- a/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
@@ -1,0 +1,237 @@
+import {act, screen} from '@testing-library/react'
+import {Suspense, type ReactNode} from 'react'
+import {hydrateRoot} from 'react-dom/client'
+import {renderToString} from 'react-dom/server'
+import {map, Observable, of, Subject, timer} from 'rxjs'
+import {afterEach, expect, test, vi} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+type CacheEntry = {
+  promise: Promise<string>
+  resolve: (value: string) => void
+  value?: string
+}
+
+const suspendCache = new Map<string, CacheEntry>()
+
+function getEntry(key: string): CacheEntry {
+  let entry = suspendCache.get(key)
+  if (!entry) {
+    let resolve!: (value: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    entry = {promise, resolve}
+    suspendCache.set(key, entry)
+  }
+  return entry
+}
+
+function resolveKey(key: string) {
+  const entry = getEntry(key)
+  entry.value = key
+  entry.resolve(key)
+}
+
+function SuspendOn({value}: {value: string}) {
+  const entry = getEntry(value)
+  if (entry.value === undefined) {
+    throw entry.promise
+  }
+  return <div data-testid="content">{entry.value}</div>
+}
+
+function withSuspense(child: ReactNode) {
+  return (
+    <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
+  )
+}
+
+let container: HTMLDivElement | undefined
+let consoleErrorSpy: ReturnType<typeof vi.spyOn> | undefined
+const roots: Array<ReturnType<typeof hydrateRoot>> = []
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    await act(async () => {
+      root.unmount()
+    })
+  }
+  container?.remove()
+  container = undefined
+  consoleErrorSpy?.mockRestore()
+  consoleErrorSpy = undefined
+  suspendCache.clear()
+})
+
+async function hydrate(ui: ReactNode, html: string) {
+  container = document.createElement('div')
+  container.innerHTML = html
+  document.body.appendChild(container)
+  consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  let root!: ReturnType<typeof hydrateRoot>
+  await act(async () => {
+    root = hydrateRoot(container!, ui)
+  })
+  roots.push(root)
+  return root
+}
+
+function hydrationErrors() {
+  return (consoleErrorSpy?.mock.calls ?? [])
+    .map((args) => String(args[0]))
+    .filter((msg) => /hydrat|did not match|Text content does not match/i.test(msg))
+}
+
+test('hydration is clean for both hooks when the observable has not emitted (initialValue everywhere)', async () => {
+  // Use a long timer so act() during hydrate does not flush an emission.
+  const observable = timer(60_000).pipe(map(() => 'later'))
+
+  function SyncApp() {
+    return <div data-testid="sync-value">{useSyncObservable(observable, 'initial')}</div>
+  }
+  function DeferredApp() {
+    return <div data-testid="deferred-value">{useObservable(observable, 'initial')}</div>
+  }
+
+  const syncHtml = renderToString(<SyncApp />)
+  expect(syncHtml).toContain('initial')
+  await hydrate(<SyncApp />, syncHtml)
+  expect(hydrationErrors()).toEqual([])
+  expect(screen.getByTestId('sync-value').textContent).toBe('initial')
+
+  await act(async () => {
+    roots.pop()?.unmount()
+  })
+  container?.remove()
+  consoleErrorSpy?.mockRestore()
+
+  const deferredHtml = renderToString(<DeferredApp />)
+  expect(deferredHtml).toContain('initial')
+  await hydrate(<DeferredApp />, deferredHtml)
+  expect(hydrationErrors()).toEqual([])
+  expect(screen.getByTestId('deferred-value').textContent).toBe('initial')
+})
+
+test('useObservable: deterministic sync-emitting observable + initialValue hydrates cleanly against server HTML showing the emission', async () => {
+  const observable = of('sync')
+
+  function App() {
+    return <div data-testid="value">{useObservable(observable, 'initial')}</div>
+  }
+
+  const html = renderToString(<App />)
+  expect(html).toContain('sync')
+  expect(html).not.toContain('initial')
+
+  await hydrate(<App />, html)
+  expect(hydrationErrors()).toEqual([])
+  expect(screen.getByTestId('value').textContent).toBe('sync')
+})
+
+test('useObservable: async observable without initialValue server-renders nothing and hydrates cleanly', async () => {
+  const observable = timer(60_000).pipe(map(() => 'later'))
+
+  function App() {
+    const value = useObservable(observable)
+    return <div data-testid="value">{value ?? ''}</div>
+  }
+
+  const html = renderToString(<App />)
+  expect(html).toBe('<div data-testid="value"></div>')
+
+  await hydrate(<App />, html)
+  expect(hydrationErrors()).toEqual([])
+  expect(screen.getByTestId('value').textContent).toBe('')
+})
+
+test('useObservable: a NON-deterministic sync emission surfaces a hydration mismatch', async () => {
+  // Documentation test: snapshot-based getServerSnapshot no longer masks per-subscription
+  // non-determinism the way an initialValue-based getServerSnapshot did.
+  // React 19 may report the mismatch via console.error and/or as an uncaught exception;
+  // either signal counts.
+  let n = 0
+  const observable = new Observable<string>((subscriber) => {
+    subscriber.next(`emit-${n++}`)
+  })
+
+  function App() {
+    return <div data-testid="value">{useObservable(observable, 'initial')}</div>
+  }
+
+  const html = renderToString(<App />)
+  expect(html).toContain('emit-0')
+
+  const uncaught: unknown[] = []
+  const onUnhandled = (event: ErrorEvent) => {
+    uncaught.push(event.error ?? event.message)
+    event.preventDefault()
+  }
+  window.addEventListener('error', onUnhandled)
+  try {
+    await hydrate(<App />, html)
+  } finally {
+    window.removeEventListener('error', onUnhandled)
+  }
+
+  const sawConsoleMismatch = hydrationErrors().length > 0
+  const sawUncaughtMismatch = uncaught.some((err) =>
+    /hydrat|did not match|Text content does not match/i.test(String(err)),
+  )
+  expect(sawConsoleMismatch || sawUncaughtMismatch).toBe(true)
+})
+
+test('useSyncObservable: an emission right after hydration that suspends replaces server-rendered content with the fallback', async () => {
+  resolveKey('v1')
+  const subject = new Subject<string>()
+
+  function App() {
+    const value = useSyncObservable(subject, 'v1')
+    return withSuspense(<SuspendOn value={value} />)
+  }
+
+  const html = renderToString(<App />)
+  expect(html).toContain('v1')
+
+  await hydrate(<App />, html)
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+
+  await act(async () => {
+    subject.next('v2')
+  })
+  // React 19 keeps prior content in the DOM with display:none while the fallback is shown.
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(screen.getByTestId('content').style.display).toBe('none')
+})
+
+test('useObservable: the same emission keeps the server-rendered content and swaps in the value without a fallback', async () => {
+  resolveKey('v1')
+  const subject = new Subject<string>()
+
+  function App() {
+    const value = useObservable(subject, 'v1')
+    return withSuspense(<SuspendOn value={value} />)
+  }
+
+  const html = renderToString(<App />)
+  expect(html).toContain('v1')
+
+  await hydrate(<App />, html)
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+
+  await act(async () => {
+    subject.next('v2')
+  })
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+  expect(screen.getByTestId('content').style.display).not.toBe('none')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+
+  await act(async () => {
+    resolveKey('v2')
+    await getEntry('v2').promise
+  })
+  expect(screen.getByTestId('content').textContent).toBe('v2')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+})

--- a/packages/react-rx/src/__tests__/useObservable.suspense.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.suspense.test.tsx
@@ -50,9 +50,7 @@ function SuspendOn({value}: {value: string}) {
 }
 
 function withSuspense(child: ReactNode) {
-  return (
-    <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
-  )
+  return <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
 }
 
 afterEach(() => {

--- a/packages/react-rx/src/__tests__/useObservable.suspense.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.suspense.test.tsx
@@ -1,0 +1,181 @@
+import {act, render, screen} from '@testing-library/react'
+import {Suspense, useState, type ReactNode} from 'react'
+import {Subject} from 'rxjs'
+import {afterEach, expect, test} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+/**
+ * Suspense interaction tests inspired by jantimon/react-hydration-rules and the
+ * useSyncExternalStore / useDeferredValue caveats on react.dev.
+ *
+ * Suspending children *depend on* the observable value so React Compiler
+ * memoization cannot prevent fallbacks by skipping the subtree.
+ */
+
+type CacheEntry = {
+  promise: Promise<string>
+  resolve: (value: string) => void
+  value?: string
+}
+
+const cache = new Map<string, CacheEntry>()
+
+function getEntry(key: string): CacheEntry {
+  let entry = cache.get(key)
+  if (!entry) {
+    let resolve!: (value: string) => void
+    const promise = new Promise<string>((r) => {
+      resolve = r
+    })
+    entry = {promise, resolve}
+    cache.set(key, entry)
+  }
+  return entry
+}
+
+function resolveKey(key: string) {
+  const entry = getEntry(key)
+  entry.value = key
+  entry.resolve(key)
+}
+
+function SuspendOn({value}: {value: string}) {
+  const entry = getEntry(value)
+  if (entry.value === undefined) {
+    throw entry.promise
+  }
+  return <div data-testid="content">{entry.value}</div>
+}
+
+function withSuspense(child: ReactNode) {
+  return (
+    <Suspense fallback={<div data-testid="fallback">loading</div>}>{child}</Suspense>
+  )
+}
+
+afterEach(() => {
+  cache.clear()
+})
+
+test('useSyncObservable: a store update that suspends replaces visible content with the fallback', async () => {
+  // Port of SuspenseFallbackOnExternalStore — uSES mutations always trigger the fallback.
+  resolveKey('v1')
+  const subject = new Subject<string>()
+
+  function App() {
+    const value = useSyncObservable(subject, 'v1')
+    return withSuspense(<SuspendOn value={value} />)
+  }
+
+  render(<App />)
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+
+  await act(async () => {
+    subject.next('v2')
+  })
+  // React 19 keeps prior content in the DOM with display:none while the fallback is shown.
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(screen.getByTestId('content').style.display).toBe('none')
+
+  await act(async () => {
+    resolveKey('v2')
+    await getEntry('v2').promise
+  })
+  expect(screen.getByTestId('content').textContent).toBe('v2')
+  expect(screen.getByTestId('content').style.display).not.toBe('none')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+})
+
+test('useObservable: a store update that suspends keeps the previous content, no fallback', async () => {
+  // Port of react.dev "preventing unwanted fallbacks" — deferred updates preserve revealed content.
+  // Even though `act` flushes deferred lanes, a suspended deferred update keeps prior UI.
+  resolveKey('v1')
+  const subject = new Subject<string>()
+
+  function App() {
+    const value = useObservable(subject, 'v1')
+    return withSuspense(<SuspendOn value={value} />)
+  }
+
+  render(<App />)
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+
+  await act(async () => {
+    subject.next('v2')
+  })
+  expect(screen.getByTestId('content').textContent).toBe('v1')
+  expect(screen.getByTestId('content').style.display).not.toBe('none')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+
+  await act(async () => {
+    resolveKey('v2')
+    await getEntry('v2').promise
+  })
+  expect(screen.getByTestId('content').textContent).toBe('v2')
+  expect(screen.queryByTestId('fallback')).toBeNull()
+})
+
+test('isStale pattern: useSyncObservable !== useObservable while a deferred update is pending', async () => {
+  // `act` flushes deferred lanes, so we capture per-render values instead of asserting DOM mid-flight.
+  resolveKey('v1')
+  resolveKey('v2')
+  const subject = new Subject<string>()
+  const pairs: Array<{sync: string; deferred: string}> = []
+
+  function App() {
+    const deferred = useObservable(subject, 'v1')
+    const sync = useSyncObservable(subject, 'v1')
+    pairs.push({sync, deferred})
+    return (
+      <div>
+        <div data-testid="sync">{sync}</div>
+        <div data-testid="deferred">{deferred}</div>
+        {withSuspense(<SuspendOn value={deferred} />)}
+      </div>
+    )
+  }
+
+  render(<App />)
+  expect(pairs.some((p) => p.sync === p.deferred && p.sync === 'v1')).toBe(true)
+
+  await act(async () => {
+    subject.next('v2')
+  })
+  // At least one render saw sync ahead of deferred (the urgent pass).
+  expect(pairs.some((p) => p.sync === 'v2' && p.deferred === 'v1')).toBe(true)
+  expect(screen.getByTestId('sync').textContent).toBe('v2')
+  expect(screen.getByTestId('deferred').textContent).toBe('v2')
+})
+
+test('newly mounted Suspense boundaries still show their fallback under useObservable', async () => {
+  // Deferral only protects already-revealed content.
+  resolveKey('ready')
+  const subject = new Subject<string>()
+
+  function App() {
+    const value = useObservable(subject, 'ready')
+    const [show, setShow] = useState(false)
+    return (
+      <div>
+        <button type="button" onClick={() => setShow(true)}>
+          show
+        </button>
+        <div data-testid="value">{value}</div>
+        {show ? withSuspense(<SuspendOn value="pending-new" />) : null}
+      </div>
+    )
+  }
+
+  render(<App />)
+  expect(screen.getByTestId('value').textContent).toBe('ready')
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'show'}).click()
+  })
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(screen.queryByTestId('content')).toBeNull() // never mounted — brand-new boundary
+})

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -504,17 +504,18 @@ test('SSR with an async observable renders the resolved initialValue', () => {
 
 test('SSR without an initialValue no longer throws', () => {
   // Contrast with useSyncObservable, which still throws without getServerSnapshot.
-  function SyncEmit() {
-    return <>{useObservable(of('sync'))}</>
-  }
-  expect(renderToString(<SyncEmit />)).toBe('sync')
-
-  function AsyncNoInitial() {
-    return <>{useObservable(scheduled('async', asyncScheduler))}</>
-  }
+  expect(renderToString(<SSRSyncEmit />)).toBe('sync')
   // Empty output matches the client's first paint (undefined).
-  expect(renderToString(<AsyncNoInitial />)).toBe('')
+  expect(renderToString(<SSRAsyncNoInitial />)).toBe('')
 })
+
+function SSRSyncEmit() {
+  return <>{useObservable(of('sync'))}</>
+}
+
+function SSRAsyncNoInitial() {
+  return <>{useObservable(scheduled('async', asyncScheduler))}</>
+}
 
 test('SSR surfaces synchronous observable errors', () => {
   // v4 rendered the initialValue on the server and deferred the explosion to client hydration.

--- a/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
@@ -1,0 +1,27 @@
+import {of} from 'rxjs'
+import {expectTypeOf, test} from 'vitest'
+
+import {useSyncObservable} from '../useSyncObservable'
+
+test('useSyncObservable with no initial value can be undefined', () => {
+  const observable = of('foo')
+
+  expectTypeOf(useSyncObservable(observable)).toEqualTypeOf<string | undefined>()
+
+  //@ts-expect-error - because initial value is not given, we can't guarantee the observable emits a sync value, so it could be undefined
+  expectTypeOf(useSyncObservable(observable)).toEqualTypeOf<string>()
+})
+
+test('return type of useSyncObservable with initial value is not undefined', () => {
+  const observable = of('foo')
+  //@ts-expect-error - because initial value is given, the return type can never be undefined
+  expectTypeOf(useSyncObservable(observable, 'bar')).toEqualTypeOf<string | undefined>()
+})
+
+test('useSyncObservable with initial value if a different type returns a union of the observed type and the initial value type', () => {
+  const observable = of('foo')
+
+  expectTypeOf(useSyncObservable(observable, 1)).toEqualTypeOf<string | number>()
+  expectTypeOf(useSyncObservable(observable, () => 1)).toEqualTypeOf<string | number>()
+  expectTypeOf(useSyncObservable(observable, 'foo')).toEqualTypeOf<string>()
+})

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -333,7 +333,9 @@ test('SSR renders the initialValue even when the observable emits synchronously'
 
 test('should not receive updates while disabled', () => {
   const values$ = new Subject<string | undefined>()
-  const {result, unmount} = renderHook(() => useSyncObservable(values$, 'initial', {disabled: true}))
+  const {result, unmount} = renderHook(() =>
+    useSyncObservable(values$, 'initial', {disabled: true}),
+  )
 
   act(() => values$.next('something'))
   expect(result.current).toBe('initial')

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -1,5 +1,5 @@
 import {act, render, renderHook} from '@testing-library/react'
-import {startTransition, useMemo} from 'react'
+import {useMemo} from 'react'
 import {renderToString} from 'react-dom/server'
 import {
   asyncScheduler,
@@ -10,13 +10,11 @@ import {
   scheduled,
   share,
   Subject,
-  throwError,
   timer,
 } from 'rxjs'
 import {expect, test} from 'vitest'
 
-import {useObservable} from '../useObservable'
-import type {UseObservableOptions} from '../useSyncObservable'
+import {useSyncObservable, type UseObservableOptions} from '../useSyncObservable'
 
 test('should subscribe immediately on component mount and unsubscribe on component unmount', async () => {
   let subscribed = false
@@ -29,7 +27,7 @@ test('should subscribe immediately on component mount and unsubscribe on compone
 
   expect(subscribed).toBe(false)
 
-  const {unmount} = renderHook(() => useObservable(observable))
+  const {unmount} = renderHook(() => useSyncObservable(observable))
   expect(subscribed).toBe(true)
 
   unmount()
@@ -45,14 +43,14 @@ test('should only subscribe once when given same observable on re-renders', asyn
 
   expect(subscriptionCount).toBe(0)
 
-  const {unmount, rerender} = renderHook(() => useObservable(observable))
+  const {unmount, rerender} = renderHook(() => useSyncObservable(observable))
   expect(subscriptionCount).toBe(1)
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
   await Promise.resolve()
 
-  renderHook(() => useObservable(observable))
+  renderHook(() => useSyncObservable(observable))
   expect(subscriptionCount).toBe(2)
 })
 
@@ -61,7 +59,7 @@ test('should not return undefined during render if initial value is given', () =
 
   const returnedValues: unknown[] = []
   function ObservableComponent() {
-    const observedValue = useObservable(observable, 'initial value')
+    const observedValue = useSyncObservable(observable, 'initial value')
     returnedValues.push(observedValue)
     return <>{observedValue}</>
   }
@@ -74,7 +72,7 @@ test('should not return undefined during render if observable is sync', () => {
 
   const returnedValues: unknown[] = []
   function ObservableComponent() {
-    const observedValue = useObservable(observable)
+    const observedValue = useSyncObservable(observable)
     returnedValues.push(observedValue)
     return <>{observedValue}</>
   }
@@ -87,7 +85,7 @@ test('should return undefined during first render if observable is async', () =>
 
   const returnedValues: unknown[] = []
   function ObservableComponent() {
-    const observedValue = useObservable(observable)
+    const observedValue = useSyncObservable(observable)
     returnedValues.push(observedValue)
     return <>{observedValue}</>
   }
@@ -97,13 +95,13 @@ test('should return undefined during first render if observable is async', () =>
 
 test('should have sync values from an observable as initial value', () => {
   const observable = of('something sync')
-  const {result} = renderHook(() => useObservable(observable))
+  const {result} = renderHook(() => useSyncObservable(observable))
   expect(result.current).toBe('something sync')
 })
 
 test('should have undefined as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useObservable(scheduled('something async', asyncScheduler)),
+    useSyncObservable(scheduled('something async', asyncScheduler)),
   )
   expect(result.current).toBeUndefined()
   unmount()
@@ -111,7 +109,7 @@ test('should have undefined as initial value from delayed observables', () => {
 
 test('should have passed initialValue as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useObservable(scheduled('something async', asyncScheduler), 'initial'),
+    useSyncObservable(scheduled('something async', asyncScheduler), 'initial'),
   )
   expect(result.current).toBe('initial')
   unmount()
@@ -119,7 +117,7 @@ test('should have passed initialValue as initial value from delayed observables'
 
 test('should rerender with initial value if component unmounts and then remounts', async () => {
   const values$ = new Subject<string>()
-  const firstHook = renderHook(() => useObservable(values$, 'initial'))
+  const firstHook = renderHook(() => useSyncObservable(values$, 'initial'))
 
   expect(firstHook.result.current).toBe('initial')
 
@@ -129,7 +127,7 @@ test('should rerender with initial value if component unmounts and then remounts
   firstHook.unmount()
   await Promise.resolve()
 
-  const nextHook = renderHook(() => useObservable(values$, 'initial2'))
+  const nextHook = renderHook(() => useSyncObservable(values$, 'initial2'))
 
   expect(nextHook.result.current).toBe('initial2')
 })
@@ -139,15 +137,15 @@ test('should share the observable between each concurrent subscribing hook', asy
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
   })
-  const firstHook = renderHook(() => useObservable(observable))
+  const firstHook = renderHook(() => useSyncObservable(observable))
   expect(firstHook.result.current).toBe(0)
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable))
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
   await Promise.resolve()
 
-  const thirdHook = renderHook(() => useObservable(observable))
+  const thirdHook = renderHook(() => useSyncObservable(observable))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
@@ -180,7 +178,7 @@ test('should restart any completed observable on mount', async () => {
     }
   }).pipe(share({connector: () => new ReplaySubject(1)}))
 
-  const firstHook = renderHook(() => useObservable(observable, 'initial'))
+  const firstHook = renderHook(() => useSyncObservable(observable, 'initial'))
   expect(firstHook.result.current).toBe('initial')
 
   act(() => notifications$.next({kind: 'next', value: 'something'}))
@@ -196,7 +194,7 @@ test('should restart any completed observable on mount', async () => {
   firstHook.unmount()
   await Promise.resolve()
 
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
@@ -208,7 +206,7 @@ test('should restart any completed observable on mount', async () => {
 
 test('should update with values from observables', () => {
   const values$ = new Subject<string>()
-  const {result, unmount} = renderHook(() => useObservable(values$))
+  const {result, unmount} = renderHook(() => useSyncObservable(values$))
 
   expect(result.current).toBe(undefined)
 
@@ -226,7 +224,7 @@ test('should re-subscribe when receiving a new observable', () => {
 
   let current$ = first$
 
-  const {result, rerender, unmount} = renderHook(() => useObservable(current$, '!!initial!!'))
+  const {result, rerender, unmount} = renderHook(() => useSyncObservable(current$, '!!initial!!'))
 
   act(() => first$.next('first 1'))
   expect(result.current).toBe('first 1')
@@ -251,7 +249,7 @@ test('should re-subscribe when receiving a new observable', () => {
 
 test('should return undefined if observable emits undefined, also when given initial value', () => {
   const values$ = new Subject<string | undefined>()
-  const {result, unmount} = renderHook(() => useObservable(values$, 'initial'))
+  const {result, unmount} = renderHook(() => useSyncObservable(values$, 'initial'))
 
   expect(result.current).toBe('initial')
 
@@ -263,9 +261,6 @@ test('should return undefined if observable emits undefined, also when given ini
 })
 
 test('should return undefined if observable emits undefined, also when given initial value, and also when unsubscribe + resubscribe', () => {
-  // Deferred updates produce urgent+deferred render pairs, so we assert the sequence of
-  // *distinct* committed values rather than every render pass (mountDeferredValueImpl /
-  // updateDeferredValueImpl may also insert Object.is bail-out passes).
   const snapshots: (string | undefined)[] = []
   const subject = new Subject<string | undefined>()
 
@@ -275,7 +270,7 @@ test('should return undefined if observable emits undefined, also when given ini
       () => subject.pipe(map((v) => (typeof v === 'string' ? `${props.prefix}-${v}` : v))),
       [props.prefix],
     )
-    snapshots.push(useObservable(observable, 'initial'))
+    snapshots.push(useSyncObservable(observable, 'initial'))
     return null
   }
 
@@ -289,14 +284,7 @@ test('should return undefined if observable emits undefined, also when given ini
   act(() => subject.next('foo again'))
   act(() => subject.next(undefined))
   act(() => subject.next('bar again'))
-
-  const distinct: (string | undefined)[] = []
-  for (const value of snapshots) {
-    if (distinct.length === 0 || !Object.is(distinct.at(-1), value)) {
-      distinct.push(value)
-    }
-  }
-  expect(distinct).toEqual([
+  expect(snapshots).toEqual([
     'initial',
     'first-foo',
     undefined,
@@ -309,9 +297,43 @@ test('should return undefined if observable emits undefined, also when given ini
   unmount()
 })
 
+test('should support SSR if an initial value is given', () => {
+  const observable = scheduled('async value', asyncScheduler)
+  function ObservableComponent() {
+    const observedValue = useSyncObservable(observable, 'initial value')
+    return <>{observedValue}</>
+  }
+
+  expect(renderToString(<ObservableComponent />)).toBe('initial value')
+})
+
+test('should throw during SSR if no initial value is defined', () => {
+  const observable = scheduled('async value', asyncScheduler)
+  function ObservableComponent() {
+    const observedValue = useSyncObservable(observable)
+    return <>{observedValue}</>
+  }
+
+  expect(() => renderToString(<ObservableComponent />)).toThrowErrorMatchingInlineSnapshot(
+    `[Error: Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.]`,
+  )
+})
+
+test('SSR renders the initialValue even when the observable emits synchronously', () => {
+  // Contrast with `useObservable`, whose getServerSnapshot returns the live snapshot so
+  // synchronous emissions win over initialValue on the server too (uSES getServerSnapshot).
+  const observable = of('sync')
+  function ObservableComponent() {
+    const observedValue = useSyncObservable(observable, 'initial')
+    return <>{observedValue}</>
+  }
+
+  expect(renderToString(<ObservableComponent />)).toBe('initial')
+})
+
 test('should not receive updates while disabled', () => {
   const values$ = new Subject<string | undefined>()
-  const {result, unmount} = renderHook(() => useObservable(values$, 'initial', {disabled: true}))
+  const {result, unmount} = renderHook(() => useSyncObservable(values$, 'initial', {disabled: true}))
 
   act(() => values$.next('something'))
   expect(result.current).toBe('initial')
@@ -322,7 +344,7 @@ test('should not receive updates while disabled', () => {
 test('should return the last value instead of the initial value when the hook is disabled after running', () => {
   const values$ = new Subject<string | undefined>()
   const {result, unmount, rerender} = renderHook<string | undefined, UseObservableOptions>(
-    (props) => useObservable(values$, 'initial', props),
+    (props) => useSyncObservable(values$, 'initial', props),
   )
   expect(result.current).toBe('initial')
   act(() => values$.next('something'))
@@ -342,7 +364,7 @@ test('should return the last value instead of the initial value when the hook is
 test('should return the actual value when the hook is disabled and then re-enabled', () => {
   const values$ = new Subject<string | undefined>()
   const {result, unmount, rerender} = renderHook<string | undefined, UseObservableOptions>(
-    (props) => useObservable(values$, 'initial', props),
+    (props) => useSyncObservable(values$, 'initial', props),
   )
   expect(result.current).toBe('initial')
   act(() => values$.next('something'))
@@ -371,158 +393,4 @@ test('should return the actual value when the hook is disabled and then re-enabl
   expect(result.current).toBe('something ending')
 
   unmount()
-})
-
-test('sync emission wins over initialValue on the first render (no flash)', () => {
-  // useDeferredValue's second arg is instance.getSnapshot(initialValue), which equals the
-  // sync emission after warm-up. mountDeferredValueImpl therefore memoizes 'sync' and may
-  // schedule a bail-out deferred pass that also returns 'sync' — never 'initial'.
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    returnedValues.push(useObservable(of('sync'), 'initial'))
-    return null
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues).not.toContain('initial')
-  expect(returnedValues[0]).toBe('sync')
-  // Pin the full sequence: first pass + optional Object.is bail-out deferred pass.
-  expect(returnedValues.every((v) => v === 'sync')).toBe(true)
-})
-
-test('remount shows the cached snapshot immediately, never the initialValue', async () => {
-  const values$ = new Subject<string>()
-  // Keep a second subscriber mounted so the module cache entry stays alive across remount.
-  const keeper = renderHook(() => useObservable(values$, 'initial'))
-
-  const log: unknown[] = []
-  function Probe() {
-    log.push(useObservable(values$, 'initial'))
-    return null
-  }
-
-  const first = render(<Probe />)
-  act(() => values$.next('a'))
-  expect(log.at(-1)).toBe('a')
-
-  first.unmount()
-  log.length = 0
-
-  render(<Probe />)
-  expect(log).not.toContain('initial')
-  expect(log[0]).toBe('a')
-
-  keeper.unmount()
-  await Promise.resolve()
-})
-
-test('an emission re-renders urgently with the previous value, then defers the new one', () => {
-  const values$ = new Subject<string>()
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    returnedValues.push(useObservable(values$, 'initial'))
-    return null
-  }
-  render(<ObservableComponent />)
-  // Mount may include a bail-out deferred pass that also returns 'initial'.
-  expect(returnedValues.every((v) => v === 'initial')).toBe(true)
-  const mountPasses = returnedValues.length
-
-  act(() => values$.next('a'))
-  // Urgent pass returns previous value ('initial'), then deferred pass returns 'a'.
-  expect(returnedValues.slice(mountPasses)).toEqual(['initial', 'a'])
-})
-
-test('emitting an identical value does not re-render', () => {
-  const values$ = new Subject<string>()
-  let renderCount = 0
-  function ObservableComponent() {
-    renderCount++
-    useObservable(values$, 'same')
-    return null
-  }
-  render(<ObservableComponent />)
-  const afterMount = renderCount
-
-  act(() => values$.next('same'))
-  expect(renderCount).toBe(afterMount)
-})
-
-test('store mutation inside startTransition still applies (uSES updates cannot be transitions)', () => {
-  // Caveat from https://react.dev/reference/react/useSyncExternalStore#caveats :
-  // if the store is mutated during a Transition, React falls back to a blocking update.
-  const values$ = new Subject<string>()
-  const {result} = renderHook(() => useObservable(values$, 'initial'))
-
-  act(() => {
-    startTransition(() => {
-      values$.next('x')
-    })
-  })
-
-  expect(result.current).toBe('x')
-})
-
-test('initialValue factories must be pure', () => {
-  const values$ = new Subject<string>()
-  let factoryCalls = 0
-  const factory = () => {
-    factoryCalls++
-    return 'initial'
-  }
-
-  const {result} = renderHook(() => useObservable(values$, factory))
-  // Pre-emission: uSES getSnapshot + useDeferredValue second arg each call the factory per render.
-  expect(factoryCalls).toBeGreaterThanOrEqual(2)
-  expect(result.current).toBe('initial')
-  const callsBeforeEmit = factoryCalls
-
-  act(() => values$.next('emitted'))
-  expect(result.current).toBe('emitted')
-  // After didEmit, getSnapshot short-circuits and the factory is no longer called.
-  expect(factoryCalls).toBe(callsBeforeEmit)
-})
-
-test('SSR renders a synchronous emission instead of the initialValue', () => {
-  // Fizz returns useDeferredValue's second arg, and getServerSnapshot returns the same
-  // live snapshot — so the server paints the sync emission.
-  const observable = of('server-sync')
-  function ObservableComponent() {
-    return <>{useObservable(observable, 'initial')}</>
-  }
-
-  expect(renderToString(<ObservableComponent />)).toBe('server-sync')
-})
-
-test('SSR with an async observable renders the resolved initialValue', () => {
-  const observable = scheduled('async value', asyncScheduler)
-  function ObservableComponent() {
-    return <>{useObservable(observable, 'initial value')}</>
-  }
-
-  expect(renderToString(<ObservableComponent />)).toBe('initial value')
-})
-
-test('SSR without an initialValue no longer throws', () => {
-  // Contrast with useSyncObservable, which still throws without getServerSnapshot.
-  function SyncEmit() {
-    return <>{useObservable(of('sync'))}</>
-  }
-  expect(renderToString(<SyncEmit />)).toBe('sync')
-
-  function AsyncNoInitial() {
-    return <>{useObservable(scheduled('async', asyncScheduler))}</>
-  }
-  // Empty output matches the client's first paint (undefined).
-  expect(renderToString(<AsyncNoInitial />)).toBe('')
-})
-
-test('SSR surfaces synchronous observable errors', () => {
-  // v4 rendered the initialValue on the server and deferred the explosion to client hydration.
-  // The snapshot-based getServerSnapshot fails the server render with the observable's error.
-  const observable = throwError(() => new Error('boom'))
-  function ObservableComponent() {
-    return <>{useObservable(observable, 'initial')}</>
-  }
-
-  expect(() => renderToString(<ObservableComponent />)).toThrow('boom')
 })

--- a/packages/react-rx/src/index.ts
+++ b/packages/react-rx/src/index.ts
@@ -2,3 +2,4 @@
 
 export * from './useObservable'
 export * from './useObservableEvent'
+export * from './useSyncObservable'

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -1,3 +1,6 @@
+// NOTE: This file intentionally duplicates `useSyncObservable.ts` — the only shared code is the
+// type-only `UseObservableOptions` import. Keep the copies in sync instead of extracting shared
+// helpers or merging the two WeakMap caches; deduplication is a planned follow-up PR.
 import {useCallback, useDeferredValue, useMemo, useSyncExternalStore} from 'react'
 import {
   asapScheduler,

--- a/packages/react-rx/src/useSyncObservable.ts
+++ b/packages/react-rx/src/useSyncObservable.ts
@@ -1,4 +1,4 @@
-import {useCallback, useDeferredValue, useMemo, useSyncExternalStore} from 'react'
+import {useCallback, useMemo, useSyncExternalStore} from 'react'
 import {
   asapScheduler,
   catchError,
@@ -11,8 +11,6 @@ import {
   tap,
   timer,
 } from 'rxjs'
-
-import type {UseObservableOptions} from './useSyncObservable'
 
 function getValue<T>(value: T): T extends () => infer U ? U : T {
   return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U
@@ -40,39 +38,48 @@ const cache = new WeakMap<Observable<any>, CacheRecord<any>>()
 
 const EMPTY_OBJECT = {}
 
+/** @public */
+export interface UseObservableOptions {
+  /**
+   * Pause the active store subscription. While `true`, later emissions do not update the component
+   * and the last received value (or `initialValue`) is returned. Does not skip the render-phase
+   * warm-up subscription — swap the observable if you need zero subscriptions.
+   */
+  disabled?: boolean
+}
+
 /**
- * Subscribe to an observable and return its latest value, with store updates deferred via
- * [`useDeferredValue`](https://react.dev/reference/react/useDeferredValue).
+ * Subscribe to an observable and return its latest value synchronously via
+ * [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).
  *
- * Urgent renders keep the previous value while a background render catches up — so children that
- * suspend on the returned value keep showing already-revealed content instead of the nearest
- * Suspense fallback. Mounts, remounts, and `<Activity>` reveals still render the current snapshot
- * synchronously (no initial-value flash).
+ * This is the v4 `useObservable` behavior. Prefer the deferred {@link useObservable} for most
+ * reads. Reach for `useSyncObservable` when the value feeds a controlled input (or must stay
+ * consistent within the same event), or when you need strict control over server markup: the
+ * server renders the resolved `initialValue` and throws without one.
  *
- * On the server this hook renders exactly what the client's first paint will show (a synchronous
- * emission when there is one, else the resolved `initialValue`, else nothing) and never throws
- * for a missing `initialValue`. Prefer {@link useSyncObservable} for controlled inputs or when you
- * need the strict v4 server-snapshot contract.
+ * **Caveat:** store mutations cannot be marked as Transitions. Suspending on a value returned by
+ * this hook replaces already-visible content with the nearest Suspense fallback — see the
+ * [useSyncExternalStore caveats](https://react.dev/reference/react/useSyncExternalStore#caveats).
  *
  * @public
  */
-export function useObservable<ObservableType extends Observable<any>>(
+export function useSyncObservable<ObservableType extends Observable<any>>(
   observable: ObservableType,
   initialValue: ObservedValueOf<ObservableType> | (() => ObservedValueOf<ObservableType>),
   options?: UseObservableOptions,
 ): ObservedValueOf<ObservableType>
 /** @public */
-export function useObservable<ObservableType extends Observable<any>>(
+export function useSyncObservable<ObservableType extends Observable<any>>(
   observable: ObservableType,
 ): undefined | ObservedValueOf<ObservableType>
 /** @public */
-export function useObservable<ObservableType extends Observable<any>, InitialValue>(
+export function useSyncObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
   initialValue: InitialValue | (() => InitialValue),
   options?: UseObservableOptions,
 ): InitialValue | ObservedValueOf<ObservableType>
 /** @public */
-export function useObservable<ObservableType extends Observable<any>, InitialValue>(
+export function useSyncObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
   initialValue?: InitialValue | (() => InitialValue),
   options: UseObservableOptions = EMPTY_OBJECT,
@@ -154,22 +161,13 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
     [instance.observable, disabled],
   )
 
-  const value = useSyncExternalStore<ObservedValueOf<ObservableType>>(
+  return useSyncExternalStore<ObservedValueOf<ObservableType>>(
     subscribe,
     () => {
       return instance.getSnapshot(initialValue)
     },
-    // Always provide getServerSnapshot so SSR never throws. The server renders
-    // exactly what the client's first render will show (sync emission, else
-    // initialValue, else undefined).
-    () => instance.getSnapshot(initialValue),
+    typeof initialValue === 'undefined'
+      ? undefined
+      : () => getValue(initialValue) as ObservedValueOf<ObservableType>,
   )
-
-  // Second arg is only read on mount / Activity reveal (mount path). Passing the
-  // live snapshot means those renders show the current value with no flash;
-  // later store updates are deferred. On the server, Fizz returns this arg and
-  // getServerSnapshot returns the same snapshot, so SSR matches the first client paint.
-  // Safe if getSnapshot throws: the useSyncExternalStore call above throws first.
-  // React Compiler may memoize this getSnapshot call — harmless, React only reads it on mount/reveal.
-  return useDeferredValue(value, instance.getSnapshot(initialValue))
 }

--- a/packages/react-rx/src/useSyncObservable.ts
+++ b/packages/react-rx/src/useSyncObservable.ts
@@ -1,3 +1,6 @@
+// NOTE: `useObservable.ts` intentionally duplicates this file (plus a useDeferredValue wrap and a
+// snapshot-based getServerSnapshot). Keep the copies in sync instead of extracting shared helpers
+// or merging the two WeakMap caches; deduplication is a planned follow-up PR.
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
 import {
   asapScheduler,

--- a/website/package.json
+++ b/website/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
+    "prebuild": "pnpm --filter react-rx build",
     "build": "next build --turbopack",
     "dev": "next dev --turbopack",
     "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",

--- a/website/src/components/ExampleSandpack.tsx
+++ b/website/src/components/ExampleSandpack.tsx
@@ -3,13 +3,15 @@ import type {ComponentProps} from 'react'
 import Sandpack from '@/components/Sandpack'
 import {readReactRxDist} from '@/utils/readExample'
 
+
 /**
  * Server wrapper that loads the local react-rx build for Sandpack in development.
  * Example source files should be read with `readExample` and passed as `files`.
- */
+*/
 export default function ExampleSandpack(
   props: Omit<ComponentProps<typeof Sandpack>, 'reactRxSource'>,
 ) {
+  
   const reactRxSource = readReactRxDist()
   return <Sandpack {...props} reactRxSource={reactRxSource} />
 }

--- a/website/src/components/ExampleSandpack.tsx
+++ b/website/src/components/ExampleSandpack.tsx
@@ -10,6 +10,6 @@ import {readReactRxDist} from '@/utils/readExample'
 export default function ExampleSandpack(
   props: Omit<ComponentProps<typeof Sandpack>, 'reactRxSource'>,
 ) {
-  const reactRxSource = process.env.NODE_ENV === 'development' ? readReactRxDist() : undefined
+  const reactRxSource = readReactRxDist()
   return <Sandpack {...props} reactRxSource={reactRxSource} />
 }

--- a/website/src/content/_meta.ts
+++ b/website/src/content/_meta.ts
@@ -2,5 +2,6 @@ export default {
   index: 'Introduction',
   guide: 'Guide',
   reference: 'API',
+  migrate: 'Migrate',
   examples: 'Examples',
 }

--- a/website/src/content/examples/_meta.ts
+++ b/website/src/content/examples/_meta.ts
@@ -6,4 +6,5 @@ export default {
   'animation': 'Animation',
   'context': 'React context',
   'sync': 'Sync rendering',
+  'suspense': 'Suspense & deferred values',
 }

--- a/website/src/content/examples/suspense.mdx
+++ b/website/src/content/examples/suspense.mdx
@@ -4,7 +4,7 @@ import Example from '@/examples/suspense'
 
 Type into the search field and watch the two panels side by side.
 
-- **Left (`useSyncObservable`)** — each keystroke is a synchronous store update. When results suspend, React replaces already-visible content with the Suspense fallback (and may log *“A component suspended while responding to synchronous input”* — open Sandpack’s console).
+- **Left (`useSyncObservable`)** — each keystroke is a synchronous store update. When results suspend, React replaces already-visible content with the Suspense fallback (and may log _“A component suspended while responding to synchronous input”_ — open Sandpack’s console).
 - **Right (`useObservable`)** — store updates are deferred. Already-revealed results stay on screen (dimmed while stale) until the new ones are ready.
 - **The input itself** reads `useSyncObservable` so typing never lags — this is exactly when you need the sync hook.
 

--- a/website/src/content/examples/suspense.mdx
+++ b/website/src/content/examples/suspense.mdx
@@ -1,0 +1,17 @@
+import Example from '@/examples/suspense'
+
+# Suspense & deferred values
+
+Type into the search field and watch the two panels side by side.
+
+- **Left (`useSyncObservable`)** — each keystroke is a synchronous store update. When results suspend, React replaces already-visible content with the Suspense fallback (and may log *“A component suspended while responding to synchronous input”* — open Sandpack’s console).
+- **Right (`useObservable`)** — store updates are deferred. Already-revealed results stay on screen (dimmed while stale) until the new ones are ready.
+- **The input itself** reads `useSyncObservable` so typing never lags — this is exactly when you need the sync hook.
+
+<Example />
+
+## Why this happens
+
+[`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore#caveats) cannot mark store mutations as Transitions, so suspending on its value triggers the nearest Suspense fallback. Wrapping the value in [`useDeferredValue`](https://react.dev/reference/react/useDeferredValue) (what `useObservable` does) is how you [prevent unwanted fallbacks](https://react.dev/reference/react/Suspense#preventing-unwanted-fallbacks) for already-revealed content.
+
+See also [jantimon/react-hydration-rules](https://github.com/jantimon/react-hydration-rules) for the broader hydration/Suspense matrix, and the React reconciler tests for `useDeferredValue` / `useSyncExternalStore` in [facebook/react](https://github.com/facebook/react). Hydration-time differences between the two hooks are covered by the library’s Vitest suite (Sandpack examples are client-only).

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -52,7 +52,7 @@ function MyComponent(props) {
 }
 ```
 
-The difference between `useObservable` and `useSyncObservable` is how *updates* propagate (deferred vs synchronous), not the first render. On the server, `useObservable` paints what the first client render will show (here `"world"`), while `useSyncObservable` would paint the `initialValue` (`"mars"`).
+The difference between `useObservable` and `useSyncObservable` is how _updates_ propagate (deferred vs synchronous), not the first render. On the server, `useObservable` paints what the first client render will show (here `"world"`), while `useSyncObservable` would paint the `initialValue` (`"mars"`).
 
 The `disabled` option pauses the hook's _active_ subscription — think of it like `pause: true`. While `disabled` is `true`, the hook will not keep a live subscription that pushes updates into the component, and it returns the last value it already received (or the `initialValue` if nothing has been received yet). Turning `disabled` back to `false` resumes the live subscription.
 
@@ -111,14 +111,14 @@ Because the fetch observable is only created (and therefore only ever subscribed
 Same signature as `useObservable`, but updates are synchronous (the previous default). Use it for controlled inputs:
 
 ```tsx
-import {useSyncObservable, useObservableEvent} from 'react-rx'
-import {Subject} from 'rxjs'
-import {map, tap} from 'rxjs'
+import type {ChangeEvent} from 'react'
+import {useObservableEvent, useSyncObservable} from 'react-rx'
+import {map, Subject, tap, type Observable} from 'rxjs'
 
 const text$ = new Subject<string>()
 
 function SearchField() {
-  const handleChange = useObservableEvent((events$) =>
+  const handleChange = useObservableEvent((events$: Observable<ChangeEvent<HTMLInputElement>>) =>
     events$.pipe(
       map((e) => e.currentTarget.value),
       tap((value) => text$.next(value)),

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -8,11 +8,18 @@ npm i react-rx rxjs
 
 ## Observable Hooks
 
+### Which one should I use?
+
+- **Default to `useObservable`** — store updates are deferred, so previews, validation, lists, and other chrome stay responsive and play nicely with Suspense.
+- **Reach for `useSyncObservable`** only when the value feeds a controlled input (caret/IME breakage or lost keystrokes under load) or must be read back synchronously in the same event. It is also the hook with the strict v4 SSR contract (server renders the `initialValue`, throws without one).
+
+See [Suspense & deferred values](/examples/suspense) for a side-by-side demo, and the [v4 → v5 migration guide](/migrate/v4-to-v5) if you are upgrading.
+
 ### useObservable()
 
 Use observables in React components with the `useObservable` hook.
 
-If you need to subscribe to an observable in your component, this hook will give you the current value from it
+If you need to subscribe to an observable in your component, this hook will give you the current value from it. Later emissions update the component at deferred priority — urgent renders keep the previous value until a background render catches up.
 
 Example:
 
@@ -29,7 +36,7 @@ function MyComponent(props) {
 }
 ```
 
-The `initialValue` argument is optional. If its omitted, the value returned from `useObservable` may be `null` initially. If the observable emits a value _synchronously_ at subscription time, that value will be used as the initial value, and any `initialValue` passed as argument to `useObservable` will be ignored:
+The `initialValue` argument is optional. If it is omitted, the value returned from `useObservable` may be `undefined` initially. If the observable emits a value _synchronously_ at subscription time, that value will be used as the initial value, and any `initialValue` passed as argument to `useObservable` will be ignored on the first render (mounts and `<Activity>` reveals are not deferred):
 
 ```tsx
 import {useMemo} from 'react'
@@ -45,9 +52,11 @@ function MyComponent(props) {
 }
 ```
 
+The difference between `useObservable` and `useSyncObservable` is how *updates* propagate (deferred vs synchronous), not the first render. On the server, `useObservable` paints what the first client render will show (here `"world"`), while `useSyncObservable` would paint the `initialValue` (`"mars"`).
+
 The `disabled` option pauses the hook's _active_ subscription — think of it like `pause: true`. While `disabled` is `true`, the hook will not keep a live subscription that pushes updates into the component, and it returns the last value it already received (or the `initialValue` if nothing has been received yet). Turning `disabled` back to `false` resumes the live subscription.
 
-Important: `disabled` does **not** skip the hook's initial warm-up subscription. `useObservable` always briefly subscribes during render so a synchronous emission can become the current snapshot. That means cold observables with subscribe-time side effects (for example `fromFetch`) still run that work even when `disabled` is `true`.
+Important: `disabled` does **not** skip the hook's initial warm-up subscription. Both hooks always briefly subscribe during render so a synchronous emission can become the current snapshot. That means cold observables with subscribe-time side effects (for example `fromFetch`) still run that work even when `disabled` is `true`.
 
 ```tsx
 import {useEffect, useState} from 'react'
@@ -96,6 +105,30 @@ function Users({shouldFetch}: {shouldFetch: boolean}) {
 ```
 
 Because the fetch observable is only created (and therefore only ever subscribed) when `shouldFetch` is true, this guarantees zero subscriptions to `fromFetch` until then.
+
+### useSyncObservable()
+
+Same signature as `useObservable`, but updates are synchronous (the previous default). Use it for controlled inputs:
+
+```tsx
+import {useSyncObservable, useObservableEvent} from 'react-rx'
+import {Subject} from 'rxjs'
+import {map, tap} from 'rxjs'
+
+const text$ = new Subject<string>()
+
+function SearchField() {
+  const handleChange = useObservableEvent((events$) =>
+    events$.pipe(
+      map((e) => e.currentTarget.value),
+      tap((value) => text$.next(value)),
+    ),
+  )
+  const text = useSyncObservable(text$, '')
+
+  return <input value={text} onChange={handleChange} />
+}
+```
 
 ### useObservableEvent()
 

--- a/website/src/content/index.md
+++ b/website/src/content/index.md
@@ -5,5 +5,6 @@
 Features:
 
 - Works well with `Observables` emitting values synchronously. You don't pay the re-render-on-mount tax.
+- Non-blocking by default — `useObservable` defers store updates; reach for `useSyncObservable` for controlled inputs.
 - Lightweight. Implemented on top of a small React Hook based core.
 - Full TypeScript support.

--- a/website/src/content/migrate/_meta.ts
+++ b/website/src/content/migrate/_meta.ts
@@ -1,0 +1,3 @@
+export default {
+  'v4-to-v5': 'v4 to v5',
+}

--- a/website/src/content/migrate/v4-to-v5.mdx
+++ b/website/src/content/migrate/v4-to-v5.mdx
@@ -4,12 +4,12 @@ v5 is a major release. This page covers every breaking change and the recommende
 
 ## Requirements
 
-| | v4 | v5 |
-| --- | --- | --- |
-| React | 18+ | `^19.2` |
-| RxJS | 7.x (operators often from `'rxjs/operators'`) | `^7.2`, import operators from `'rxjs'` |
-| Node | (unspecified) | `>=22.12` |
-| Module format | CJS + ESM | ESM-only |
+|               | v4                                            | v5                                     |
+| ------------- | --------------------------------------------- | -------------------------------------- |
+| React         | 18+                                           | `^19.2`                                |
+| RxJS          | 7.x (operators often from `'rxjs/operators'`) | `^7.2`, import operators from `'rxjs'` |
+| Node          | (unspecified)                                 | `>=22.12`                              |
+| Module format | CJS + ESM                                     | ESM-only                               |
 
 See the [RxJS import migration guide](https://rxjs.dev/guide/importing#how-to-migrate) if you still import from `'rxjs/operators'`.
 

--- a/website/src/content/migrate/v4-to-v5.mdx
+++ b/website/src/content/migrate/v4-to-v5.mdx
@@ -17,7 +17,7 @@ See the [RxJS import migration guide](https://rxjs.dev/guide/importing#how-to-mi
 
 In v4, `useObservable` was built on [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) and forced **synchronous** React updates. Under load that blocks the main thread for chrome that does not need to be sync — validation, presence, previews, permissions, and similar.
 
-v5 moves the established pattern from [sanity-io/sanity#13799](https://github.com/sanity-io/sanity/pull/13799) into the library:
+v5 makes that the library default:
 
 - **`useObservable`** — store updates are deferred with `useDeferredValue`. Urgent renders keep the previous value; a background render catches up. Mounts, remounts, and `<Activity>` reveals still show the live snapshot (no initial-value flash).
 - **`useSyncObservable`** — exact v4 synchronous behavior, including the strict server snapshot (`initialValue` on the server, throws without one).

--- a/website/src/content/migrate/v4-to-v5.mdx
+++ b/website/src/content/migrate/v4-to-v5.mdx
@@ -1,0 +1,62 @@
+# Migrating from v4 to v5
+
+v5 is a major release. This page covers every breaking change and the recommended upgrade path for the headline hook change.
+
+## Requirements
+
+| | v4 | v5 |
+| --- | --- | --- |
+| React | 18+ | `^19.2` |
+| RxJS | 7.x (operators often from `'rxjs/operators'`) | `^7.2`, import operators from `'rxjs'` |
+| Node | (unspecified) | `>=22.12` |
+| Module format | CJS + ESM | ESM-only |
+
+See the [RxJS import migration guide](https://rxjs.dev/guide/importing#how-to-migrate) if you still import from `'rxjs/operators'`.
+
+## Deferred `useObservable` (headline change)
+
+In v4, `useObservable` was built on [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore) and forced **synchronous** React updates. Under load that blocks the main thread for chrome that does not need to be sync — validation, presence, previews, permissions, and similar.
+
+v5 moves the established pattern from [sanity-io/sanity#13799](https://github.com/sanity-io/sanity/pull/13799) into the library:
+
+- **`useObservable`** — store updates are deferred with `useDeferredValue`. Urgent renders keep the previous value; a background render catches up. Mounts, remounts, and `<Activity>` reveals still show the live snapshot (no initial-value flash).
+- **`useSyncObservable`** — exact v4 synchronous behavior, including the strict server snapshot (`initialValue` on the server, throws without one).
+
+### What you may notice
+
+- **Controlled inputs** can lag or lose caret position under load if they keep using `useObservable` — switch those reads to `useSyncObservable`.
+- The **rendered value can briefly trail the store**, so imperative reads or equality checks against it can observe a stale value. Keep a sync read for write-path equality when needed.
+- **Render-count / test assertions** may see extra passes: one Object.is bail-out pass on mount when the snapshot is defined, and an urgent-plus-deferred pair per emission.
+- **SSR** now renders synchronous emissions instead of the `initialValue`, and no longer throws when `initialValue` is omitted. Non-deterministic sync emissions can surface hydration mismatches that were previously masked. Synchronously erroring observables now fail the server render instead of exploding at hydration.
+
+### Recommended: targeted migration
+
+Keep calling `useObservable` everywhere. Switch only controlled-input (or same-event synchronous) reads to `useSyncObservable`:
+
+```tsx
+// Before (v4)
+const text = useObservable(text$, '')
+const items = useObservable(items$, [])
+
+// After (v5) — only the input value needs to be sync
+const text = useSyncObservable(text$, '')
+const items = useObservable(items$, [])
+```
+
+Also remove redundant wrappers that are now built in:
+
+```tsx
+// Before
+const results = useDeferredValue(useObservable(results$))
+
+// After
+const results = useObservable(results$)
+```
+
+### Fallback: mechanical rename
+
+If you need a zero-behavior-change upgrade day, rename every `useObservable` → `useSyncObservable`, then adopt deferral incrementally by switching non-input reads back to `useObservable`.
+
+### See it in action
+
+The [Suspense & deferred values](/examples/suspense) example puts both hooks side by side on a search UI.

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -2,15 +2,19 @@
 
 ## useObservable()
 
-A React hook that returns the current/latest value from an observable
+A React hook that returns the current/latest value from an observable. Store updates are **deferred by default** via [`useDeferredValue`](https://react.dev/reference/react/useDeferredValue): urgent renders keep the previous value while a background render catches up. That makes it safe to suspend on the returned value without replacing already-revealed UI with a Suspense fallback.
+
+Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash). On the server, this hook renders exactly what the client's first paint will show (a synchronous emission when there is one, else the resolved `initialValue`, else nothing) and never throws for a missing `initialValue`.
+
+Prefer this hook for previews, validation, lists, and other non-input reads. Use [`useSyncObservable`](#usesyncobservable) for controlled inputs or strict SSR control.
 
 **Signature**
 
 ```ts
-function useObservable<T>(observable$: Observable<T>): T | null
+function useObservable<T>(observable$: Observable<T>): T | undefined
 function useObservable<T>(
   observable$: Observable<T>,
-  initialValue: T | undefined,
+  initialValue: T | (() => T),
   options?: UseObservableOptions,
 ): T
 
@@ -33,6 +37,48 @@ function MyComponent() {
   const number = useObservable(observable, 0)
 
   return <>The number is {number}</>
+}
+```
+
+## useSyncObservable()
+
+A React hook that returns the current/latest value from an observable **synchronously** via [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore). This is the v4 `useObservable` behavior.
+
+Use it when the value feeds a controlled input (or must stay consistent within the same event), or when you need strict control over server markup: the server renders the resolved `initialValue` and throws without one.
+
+**Caveat:** store mutations cannot be marked as Transitions. Suspending on a value returned by this hook replaces already-visible content with the nearest Suspense fallback — see the [useSyncExternalStore caveats](https://react.dev/reference/react/useSyncExternalStore#caveats). Compare the two hooks in the [Suspense example](/examples/suspense).
+
+**Signature**
+
+```ts
+function useSyncObservable<T>(observable$: Observable<T>): T | undefined
+function useSyncObservable<T>(
+  observable$: Observable<T>,
+  initialValue: T | (() => T),
+  options?: UseObservableOptions,
+): T
+```
+
+**Example**
+
+```tsx
+import {useSyncObservable, useObservableEvent} from 'react-rx'
+import {Subject} from 'rxjs'
+import {map, tap} from 'rxjs'
+
+const text$ = new Subject<string>()
+
+function SearchField() {
+  const handleChange = useObservableEvent((events$) =>
+    events$.pipe(
+      map((e) => e.currentTarget.value),
+      tap((value) => text$.next(value)),
+    ),
+  )
+  // Controlled input values must update synchronously.
+  const text = useSyncObservable(text$, '')
+
+  return <input value={text} onChange={handleChange} />
 }
 ```
 

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -62,14 +62,14 @@ function useSyncObservable<T>(
 **Example**
 
 ```tsx
-import {useSyncObservable, useObservableEvent} from 'react-rx'
-import {Subject} from 'rxjs'
-import {map, tap} from 'rxjs'
+import type {ChangeEvent} from 'react'
+import {useObservableEvent, useSyncObservable} from 'react-rx'
+import {map, Subject, tap, type Observable} from 'rxjs'
 
 const text$ = new Subject<string>()
 
 function SearchField() {
-  const handleChange = useObservableEvent((events$) =>
+  const handleChange = useObservableEvent((events$: Observable<ChangeEvent<HTMLInputElement>>) =>
     events$.pipe(
       map((e) => e.currentTarget.value),
       tap((value) => text$.next(value)),

--- a/website/src/examples/form-data/FormDataExample.tsx
+++ b/website/src/examples/form-data/FormDataExample.tsx
@@ -6,6 +6,7 @@ import {
 import {
   useObservable,
   useObservableEvent,
+  useSyncObservable,
 } from 'react-rx'
 import {
   type Observable,
@@ -112,7 +113,8 @@ function FormDataExample() {
     ),
   )
 
-  const formData = useObservable(data$, {
+  // Form field values feed controlled inputs — must stay synchronous.
+  const formData = useSyncObservable(data$, {
     title: '',
     description: '',
   })

--- a/website/src/examples/search/SearchExample.tsx
+++ b/website/src/examples/search/SearchExample.tsx
@@ -1,11 +1,8 @@
-import {
-  ChangeEvent,
-  useDeferredValue,
-  useMemo,
-} from 'react'
+import {ChangeEvent, useMemo} from 'react'
 import {
   useObservable,
   useObservableEvent,
+  useSyncObservable,
 } from 'react-rx'
 import {
   distinctUntilChanged,
@@ -97,11 +94,10 @@ function SearchExample() {
     [],
   )
 
-  const keyword = useObservable(keyword$, '')
+  // Controlled input value must update synchronously.
+  const keyword = useSyncObservable(keyword$, '')
+  // Results are deferred by default via useObservable (no manual useDeferredValue).
   const results = useObservable(results$)
-  // Uses React Concurrent Rendering to defer rendering of results if the search query changes before the results are done rendering
-  const deferredResults =
-    useDeferredValue(results)
 
   return (
     <>
@@ -116,7 +112,7 @@ function SearchExample() {
         The more characters you type, the faster
         the results will appear
       </div>
-      {deferredResults}
+      {results}
     </>
   )
 }

--- a/website/src/examples/suspense/SuspenseExample.tsx
+++ b/website/src/examples/suspense/SuspenseExample.tsx
@@ -1,0 +1,175 @@
+import {
+  ChangeEvent,
+  Suspense,
+  use,
+} from 'react'
+import {
+  useObservable,
+  useObservableEvent,
+  useSyncObservable,
+} from 'react-rx'
+import {map, Subject, tap} from 'rxjs'
+
+// Shared by the input and both panels. Each hook file has its own
+// WeakMap, so dual reads subscribe twice — fine for this demo.
+const keyword$ = new Subject<string>()
+
+type CacheEntry = {
+  promise: Promise<string[]>
+  value?: string[]
+}
+
+const resultsCache = new Map<
+  string,
+  CacheEntry
+>()
+
+function searchHits(
+  keyword: string,
+): Promise<string[]> {
+  let entry = resultsCache.get(keyword)
+  if (!entry) {
+    entry = {
+      promise: new Promise((resolve) => {
+        // Shorter keywords take longer — mirrors the search example.
+        const delay = Math.max(
+          200,
+          (10 - keyword.length) * 80,
+        )
+        setTimeout(() => {
+          const hits = Array.from(
+            {length: Math.max(1, keyword.length)},
+            (_, i) =>
+              `Hit #${i + 1} for “${keyword}”`,
+          )
+          entry!.value = hits
+          resolve(hits)
+        }, delay)
+      }),
+    }
+    resultsCache.set(keyword, entry)
+  }
+  return entry.promise
+}
+
+function SlowResults({
+  keyword,
+}: {
+  keyword: string
+}) {
+  if (!keyword) {
+    return (
+      <p>Type to search — results suspend.</p>
+    )
+  }
+  // use() suspends until the promise resolves (same idea as throwing a promise).
+  const hits = use(searchHits(keyword))
+  return (
+    <ul>
+      {hits.map((hit) => (
+        <li key={hit}>{hit}</li>
+      ))}
+    </ul>
+  )
+}
+
+function SyncPanel() {
+  const keyword = useSyncObservable(
+    keyword$,
+    '',
+  )
+  return (
+    <section
+      style={{
+        flex: 1,
+        border: '1px solid #ccc',
+        padding: 12,
+      }}
+    >
+      <h3>useSyncObservable</h3>
+      <p style={{fontSize: 13, opacity: 0.8}}>
+        Synchronous store updates. Typing
+        discards visible results and shows the
+        Suspense fallback (also logs React’s
+        “suspended while responding to synchronous
+        input” warning — open the console).
+      </p>
+      <Suspense
+        fallback={<p>Loading results…</p>}
+      >
+        <SlowResults keyword={keyword} />
+      </Suspense>
+    </section>
+  )
+}
+
+function DeferredPanel() {
+  const keyword = useObservable(keyword$, '')
+  // Dual read for the isStale dimming pattern (two module caches).
+  const syncKeyword = useSyncObservable(
+    keyword$,
+    '',
+  )
+  const isStale = keyword !== syncKeyword
+  return (
+    <section
+      style={{
+        flex: 1,
+        border: '1px solid #ccc',
+        padding: 12,
+        opacity: isStale ? 0.5 : 1,
+      }}
+    >
+      <h3>useObservable</h3>
+      <p style={{fontSize: 13, opacity: 0.8}}>
+        Deferred store updates. Previous results
+        stay on screen (dimmed while stale) until
+        the new ones are ready — no fallback flash.
+      </p>
+      <Suspense
+        fallback={<p>Loading results…</p>}
+      >
+        <SlowResults keyword={keyword} />
+      </Suspense>
+    </section>
+  )
+}
+
+export default function App() {
+  // Controlled input value must update synchronously.
+  const keyword = useSyncObservable(
+    keyword$,
+    '',
+  )
+  const handleInput = useObservableEvent<
+    ChangeEvent<HTMLInputElement>,
+    any
+  >((input$) =>
+    input$.pipe(
+      map((e) => e.currentTarget.value),
+      tap((value) => keyword$.next(value)),
+    ),
+  )
+
+  return (
+    <div>
+      <input
+        type="search"
+        style={{width: '100%', marginBottom: 12}}
+        value={keyword}
+        placeholder="Type a keyword"
+        onChange={handleInput}
+      />
+      <div
+        style={{
+          display: 'flex',
+          gap: 12,
+          alignItems: 'flex-start',
+        }}
+      >
+        <SyncPanel />
+        <DeferredPanel />
+      </div>
+    </div>
+  )
+}

--- a/website/src/examples/suspense/SuspenseExample.tsx
+++ b/website/src/examples/suspense/SuspenseExample.tsx
@@ -1,8 +1,4 @@
-import {
-  ChangeEvent,
-  Suspense,
-  use,
-} from 'react'
+import {ChangeEvent, Suspense, use} from 'react'
 import {
   useObservable,
   useObservableEvent,
@@ -19,10 +15,7 @@ type CacheEntry = {
   value?: string[]
 }
 
-const resultsCache = new Map<
-  string,
-  CacheEntry
->()
+const resultsCache = new Map<string, CacheEntry>()
 
 function searchHits(
   keyword: string,
@@ -74,10 +67,7 @@ function SlowResults({
 }
 
 function SyncPanel() {
-  const keyword = useSyncObservable(
-    keyword$,
-    '',
-  )
+  const keyword = useSyncObservable(keyword$, '')
   return (
     <section
       style={{
@@ -88,11 +78,11 @@ function SyncPanel() {
     >
       <h3>useSyncObservable</h3>
       <p style={{fontSize: 13, opacity: 0.8}}>
-        Synchronous store updates. Typing
-        discards visible results and shows the
-        Suspense fallback (also logs React’s
-        “suspended while responding to synchronous
-        input” warning — open the console).
+        Synchronous store updates. Typing discards
+        visible results and shows the Suspense
+        fallback (also logs React’s “suspended
+        while responding to synchronous input”
+        warning — open the console).
       </p>
       <Suspense
         fallback={<p>Loading results…</p>}
@@ -124,7 +114,8 @@ function DeferredPanel() {
       <p style={{fontSize: 13, opacity: 0.8}}>
         Deferred store updates. Previous results
         stay on screen (dimmed while stale) until
-        the new ones are ready — no fallback flash.
+        the new ones are ready — no fallback
+        flash.
       </p>
       <Suspense
         fallback={<p>Loading results…</p>}
@@ -137,10 +128,7 @@ function DeferredPanel() {
 
 export default function App() {
   // Controlled input value must update synchronously.
-  const keyword = useSyncObservable(
-    keyword$,
-    '',
-  )
+  const keyword = useSyncObservable(keyword$, '')
   const handleInput = useObservableEvent<
     ChangeEvent<HTMLInputElement>,
     any

--- a/website/src/examples/suspense/index.tsx
+++ b/website/src/examples/suspense/index.tsx
@@ -1,0 +1,15 @@
+import ExampleSandpack from '@/components/ExampleSandpack'
+import {readExample} from '@/utils/readExample'
+
+export default function Example() {
+  return (
+    <ExampleSandpack
+      files={{
+        '/App.tsx': readExample(
+          'suspense',
+          'SuspenseExample.tsx',
+        ),
+      }}
+    />
+  )
+}

--- a/website/src/examples/todo-app/TodoApp.example.tsx
+++ b/website/src/examples/todo-app/TodoApp.example.tsx
@@ -6,6 +6,7 @@ import {
 import {
   useObservable,
   useObservableEvent,
+  useSyncObservable,
 } from 'react-rx'
 import {
   filter,
@@ -79,7 +80,8 @@ function TodoApp() {
     [],
   )
 
-  const text = useObservable(text$, '')
+  // Controlled input value must update synchronously to avoid caret/IME issues.
+  const text = useSyncObservable(text$, '')
   const items = useObservable(items$, [])
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`useObservable` now defers store updates with `useDeferredValue` by default (the pattern proven in [sanity-io/sanity#13799](https://github.com/sanity-io/sanity/pull/13799)). Mounts, remounts, and `<Activity>` reveals still render the live snapshot (no initial-value flash). SSR paints what the first client render will show and no longer throws without an `initialValue`.

New `useSyncObservable` preserves the exact v4 synchronous behavior (including the strict `getServerSnapshot` contract) for controlled inputs and precise SSR control.

## Library

- `git mv` of the previous implementation to `useSyncObservable.ts` (rename only + JSDoc)
- Brand-new standalone `useObservable.ts` (intentional duplication, marked with NOTE comments in both files — shared-core dedup is a follow-up PR) with snapshot-based `getServerSnapshot` and `useDeferredValue(value, instance.getSnapshot(initialValue))`

## Tests

- Existing suite retargeted to `useSyncObservable` (proves sync hook === v4)
- New deferred semantics, Suspense fallback comparison, and SSR/hydration suites
- Errors / Strict Mode parameterized across both hooks; new Activity test pins that hidden re-renders never flash the `initialValue`
- `pnpm build` / `pnpm lint` / `pnpm knip` / `pnpm test` (166, both Vitest projects) / `tsc -p packages/react-rx` all green; website production build (`next build` + pagefind) verified

## Docs & examples

- Controlled-input examples (`todo-app`, `search`, `form-data`) use `useSyncObservable`; search drops its manual `useDeferredValue`
- New Suspense & deferred values comparison page (text-input driven)
- New v4 → v5 migration guide (targeted migration recommended)
- API + guide updated for the two-hook API

## Demo

[suspense-hooks-comparison-demo.mp4](https://cursor.com/agents/bc-4082df96-2191-490a-b268-bcacdd39ee7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuspense-hooks-comparison-demo.mp4)

[Suspense example after typing](https://cursor.com/agents/bc-4082df96-2191-490a-b268-bcacdd39ee7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsuspense-example.webp)
[Reference docs for both hooks](https://cursor.com/agents/bc-4082df96-2191-490a-b268-bcacdd39ee7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Freference-hooks.webp)
[Todo app controlled input](https://cursor.com/agents/bc-4082df96-2191-490a-b268-bcacdd39ee7d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftodo-app-input.webp)

## Migration (targeted)

```tsx
// Only controlled-input reads need the sync hook
const text = useSyncObservable(text$, '')
const items = useObservable(items$, [])
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4082df96-2191-490a-b268-bcacdd39ee7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4082df96-2191-490a-b268-bcacdd39ee7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

