### PR TITLE
feat: add useObservablePromise for Suspense-ready data fetching

### DIFF
--- a/.changeset/use-observable-promise.md
+++ b/.changeset/use-observable-promise.md
@@ -1,0 +1,5 @@
+---
+"react-rx": minor
+---
+
+Add `useObservablePromise` and `preloadObservablePromise`: Suspense-ready data fetching returning a `use()`-compatible promise, with `{disabled, ttl}` options.

--- a/packages/react-rx/src/__tests__/useObservablePromise.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.activity.test.tsx
@@ -164,6 +164,53 @@ test('visible Activity hide/show preserves fulfilled value across toggles', asyn
   expect(screen.getByTestId('value').textContent).toBe('fetched')
 })
 
+test('entry evicted while hidden: reveal shows the cached value without fallback or refetch', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+  let fallbackCount = 0
+
+  function Child() {
+    const value = use(useObservablePromise(observable, {ttl: 40}))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <ToggleActivity>
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Child />
+      </Suspense>
+    </ToggleActivity>,
+  )
+  await act(async () => {
+    resolve('fetched')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('fetched'))
+  const fallbacksBeforeHide = fallbackCount
+  expect(subscriptions).toBe(1)
+
+  // Hide: the store subscription is torn down, so after `ttl` the shared cache
+  // entry is evicted. The component is still mounted and must keep its pinned
+  // entry — otherwise reveal would find a fresh pending entry and re-suspend.
+  await toggle()
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 100))
+  })
+
+  await toggle()
+  expect(screen.getByTestId('value').textContent).toBe('fetched')
+  expect(fallbackCount).toBe(fallbacksBeforeHide)
+  // The source completed after its single emission — reveal must not refetch.
+  expect(subscriptions).toBe(1)
+})
+
 test('long-lived source: share retention keeps the connection during ttl, so hidden emissions update the cache', async () => {
   const subject = new Subject<string>()
   let subscriptions = 0

--- a/packages/react-rx/src/__tests__/useObservablePromise.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.activity.test.tsx
@@ -1,0 +1,209 @@
+import {act, render, screen, waitFor} from '@testing-library/react'
+import {Activity, Suspense, use, useState, type ReactNode} from 'react'
+import {defer, from, Observable, Subject} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservablePromise} from '../useObservablePromise'
+
+/**
+ * Documents how `useObservablePromise` interacts with React 19.2's `<Activity>`.
+ *
+ * Unlike `useObservable` (built on `useSyncExternalStore` + effects), this hook
+ * returns a Promise read with `use()`, which Activity pre-rendering *does*
+ * detect — so hidden boundaries can start fetching before they become visible.
+ *
+ * @see https://react.dev/reference/react/Activity#pre-rendering-content-thats-likely-to-become-visible
+ */
+
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+function Fallback({onRender}: {onRender?: () => void}) {
+  onRender?.()
+  return <div data-testid="fallback">loading</div>
+}
+
+function ToggleActivity({children}: {children: ReactNode}) {
+  const [mode, setMode] = useState<'visible' | 'hidden'>('visible')
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setMode((m) => (m === 'visible' ? 'hidden' : 'visible'))}
+      >
+        toggle
+      </button>
+      <Activity mode={mode}>{children}</Activity>
+    </>
+  )
+}
+
+async function toggle() {
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+}
+
+test('hidden Activity pre-render starts the source subscription without effects', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  function Child() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <Activity mode="hidden">
+      <Suspense fallback={<Fallback />}>
+        <Child />
+      </Suspense>
+    </Activity>,
+  )
+
+  // Eager render-phase resolver starts the fetch even while hidden.
+  expect(subscriptions).toBe(1)
+
+  await act(async () => {
+    resolve('prefetched')
+    await promise
+  })
+
+  // Still hidden — content may be in the DOM with display:none once resolved.
+  await waitFor(() => {
+    const el = screen.queryByTestId('value')
+    expect(el?.textContent).toBe('prefetched')
+  })
+})
+
+test('promise that resolves while hidden appears without fallback on reveal', async () => {
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => from(promise))
+  let fallbackCount = 0
+
+  function Child() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  const {rerender} = await renderAsync(
+    <Activity mode="hidden">
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Child />
+      </Suspense>
+    </Activity>,
+  )
+
+  await act(async () => {
+    resolve('ready')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('ready'))
+  const fallbacksWhileHidden = fallbackCount
+
+  await act(async () => {
+    rerender(
+      <Activity mode="visible">
+        <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+          <Child />
+        </Suspense>
+      </Activity>,
+    )
+  })
+
+  expect(screen.getByTestId('value').textContent).toBe('ready')
+  // Reveal must not re-activate Suspense.
+  expect(fallbackCount).toBe(fallbacksWhileHidden)
+})
+
+test('visible Activity hide/show preserves fulfilled value across toggles', async () => {
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => from(promise))
+
+  function Child() {
+    const value = use(useObservablePromise(observable, {ttl: 500}))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <ToggleActivity>
+      <Suspense fallback={<Fallback />}>
+        <Child />
+      </Suspense>
+    </ToggleActivity>,
+  )
+
+  await act(async () => {
+    resolve('fetched')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('fetched'))
+
+  await toggle()
+  expect(screen.getByTestId('value').textContent).toBe('fetched')
+
+  await toggle()
+  expect(screen.getByTestId('value').textContent).toBe('fetched')
+})
+
+test('long-lived source: share retention keeps the connection during ttl, so hidden emissions update the cache', async () => {
+  const subject = new Subject<string>()
+  let subscriptions = 0
+  const observable = new Observable<string>((subscriber) => {
+    subscriptions++
+    const sub = subject.subscribe(subscriber)
+    return () => sub.unsubscribe()
+  })
+
+  function Child() {
+    const value = use(useObservablePromise(observable, {ttl: 200}))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <ToggleActivity>
+      <Suspense fallback={<Fallback />}>
+        <Child />
+      </Suspense>
+    </ToggleActivity>,
+  )
+
+  await act(async () => {
+    subject.next('visible-1')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('visible-1'))
+  expect(subscriptions).toBe(1)
+
+  await toggle()
+  // Unlike useObservable (which drops the source immediately), the TTL share
+  // retention keeps the multicast alive briefly — emissions during that window
+  // update the cached promise so reveal can show the latest value.
+  await act(async () => {
+    subject.next('hidden-cached')
+  })
+
+  await toggle()
+  expect(screen.getByTestId('value').textContent).toBe('hidden-cached')
+  await act(async () => {
+    subject.next('visible-2')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('visible-2'))
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
@@ -1,0 +1,226 @@
+import {act, render, screen} from '@testing-library/react'
+import {
+  Suspense,
+  use,
+  useDeferredValue,
+  useState,
+  useTransition,
+  type ReactNode,
+} from 'react'
+import {BehaviorSubject} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservablePromise} from '../useObservablePromise'
+
+/**
+ * Port of the dai-shi concurrent-rendering tearing checks relevant to external
+ * stores, adapted to vitest/jsdom.
+ *
+ * External-store libraries (react-rxjs, zustand, redux, this hook) pass the
+ * "no tearing finally" checks and generally cannot support interrupt/branching
+ * (time slicing / wip state) — those require React-managed state. We assert the
+ * tearing checks and document interrupt/branching as out of scope.
+ *
+ * @see https://github.com/dai-shi/will-this-react-global-state-work-in-concurrent-rendering
+ */
+
+const COUNTERS = 20
+
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+function slowFib(n: number): number {
+  if (n <= 1) return n
+  return slowFib(n - 1) + slowFib(n - 2)
+}
+
+function Counter({
+  count$,
+  index,
+  waste = 18,
+}: {
+  count$: BehaviorSubject<number>
+  index: number
+  waste?: number
+}) {
+  const value = use(useObservablePromise(count$))
+  // Artificial expensive render to widen the concurrent window.
+  slowFib(waste)
+  return <span data-testid={`c-${index}`}>{value}</span>
+}
+
+function readAll(): number[] {
+  return Array.from({length: COUNTERS}, (_, i) =>
+    Number(screen.getByTestId(`c-${i}`).textContent),
+  )
+}
+
+test('no tearing finally on update (startTransition)', async () => {
+  const count$ = new BehaviorSubject(0)
+
+  function App() {
+    const [, startTransition] = useTransition()
+    const [local, setLocal] = useState(0)
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            count$.next(count$.value + 1)
+            startTransition(() => setLocal((n) => n + 1))
+          }}
+        >
+          inc
+        </button>
+        <span data-testid="local">{local}</span>
+        <Suspense fallback={<div>loading</div>}>
+          {Array.from({length: COUNTERS}, (_, i) => (
+            <Counter key={i} count$={count$} index={i} />
+          ))}
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<App />)
+  expect(new Set(readAll()).size).toBe(1)
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'inc'}).click()
+  })
+
+  const values = readAll()
+  expect(new Set(values).size).toBe(1)
+  expect(values[0]).toBe(1)
+})
+
+test('no tearing finally on mount (startTransition)', async () => {
+  const count$ = new BehaviorSubject(0)
+
+  function App() {
+    const [mounted, setMounted] = useState(false)
+    const [, startTransition] = useTransition()
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            count$.next(1)
+            startTransition(() => setMounted(true))
+          }}
+        >
+          mount
+        </button>
+        <Suspense fallback={<div>loading</div>}>
+          {mounted &&
+            Array.from({length: COUNTERS}, (_, i) => (
+              <Counter key={i} count$={count$} index={i} />
+            ))}
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<App />)
+  await act(async () => {
+    screen.getByRole('button', {name: 'mount'}).click()
+  })
+
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  const values = readAll()
+  expect(values).toHaveLength(COUNTERS)
+  expect(new Set(values).size).toBe(1)
+  expect(values[0]).toBe(1)
+})
+
+test('no tearing finally on update (useDeferredValue)', async () => {
+  const count$ = new BehaviorSubject(0)
+
+  function App() {
+    const [version, setVersion] = useState(0)
+    const deferred = useDeferredValue(version)
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            count$.next(count$.value + 1)
+            setVersion((v) => v + 1)
+          }}
+        >
+          inc
+        </button>
+        <span data-testid="deferred">{deferred}</span>
+        <Suspense fallback={<div>loading</div>}>
+          {Array.from({length: COUNTERS}, (_, i) => (
+            <Counter key={i} count$={count$} index={i} />
+          ))}
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<App />)
+  await act(async () => {
+    screen.getByRole('button', {name: 'inc'}).click()
+  })
+
+  const values = readAll()
+  expect(new Set(values).size).toBe(1)
+  expect(values[0]).toBe(1)
+})
+
+test('no tearing finally on mount (useDeferredValue)', async () => {
+  const count$ = new BehaviorSubject(0)
+
+  function App() {
+    const [mounted, setMounted] = useState(false)
+    const deferredMounted = useDeferredValue(mounted)
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => {
+            count$.next(1)
+            setMounted(true)
+          }}
+        >
+          mount
+        </button>
+        <Suspense fallback={<div>loading</div>}>
+          {deferredMounted &&
+            Array.from({length: COUNTERS}, (_, i) => (
+              <Counter key={i} count$={count$} index={i} />
+            ))}
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<App />)
+  await act(async () => {
+    screen.getByRole('button', {name: 'mount'}).click()
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  const values = readAll()
+  expect(values).toHaveLength(COUNTERS)
+  expect(new Set(values).size).toBe(1)
+  expect(values[0]).toBe(1)
+})
+
+/*
+ * Interrupt (time slicing) and branching (wip state) are not supported for
+ * external-store subscriptions — the same profile as react-rxjs / zustand /
+ * redux in the dai-shi harness. Not asserted here.
+ */

--- a/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.concurrent.test.tsx
@@ -1,5 +1,6 @@
 import {act, render, screen} from '@testing-library/react'
 import {
+  memo,
   Suspense,
   use,
   useDeferredValue,
@@ -7,10 +8,11 @@ import {
   useTransition,
   type ReactNode,
 } from 'react'
+import {createRoot} from 'react-dom/client'
 import {BehaviorSubject} from 'rxjs'
 import {expect, test} from 'vitest'
 
-import {useObservablePromise} from '../useObservablePromise'
+import {useObservablePromise, type ObservablePromise} from '../useObservablePromise'
 
 /**
  * Port of the dai-shi concurrent-rendering tearing checks relevant to external
@@ -221,6 +223,139 @@ test('no tearing finally on mount (useDeferredValue)', async () => {
 
 /*
  * Interrupt (time slicing) and branching (wip state) are not supported for
- * external-store subscriptions — the same profile as react-rxjs / zustand /
- * redux in the dai-shi harness. Not asserted here.
+ * DIRECT external-store reads — the same profile as react-rxjs / zustand /
+ * redux in the dai-shi harness: the uSES re-render triggered by an emission is
+ * scheduled at sync priority. The test below proves the supported userland
+ * escape hatch: `useDeferredValue(promise)` + `memo` moves expensive
+ * re-renders onto the deferred lane, which IS time-sliced and interruptible.
+ * Branching/wip-state semantics remain out of scope.
  */
+
+const SLOW_ITEMS = 25
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function until(predicate: () => boolean, timeoutMs = 5000, intervalMs = 10): Promise<void> {
+  const start = performance.now()
+  while (!predicate()) {
+    if (performance.now() - start > timeoutMs) {
+      throw new Error('Timed out waiting for condition')
+    }
+    // oxlint-disable-next-line no-await-in-loop -- deliberate polling
+    await wait(intervalMs)
+  }
+}
+
+/** Find the fib(n) whose computation takes at least `targetMs` on this machine. */
+function calibrateWaste(targetMs: number): number {
+  for (let n = 18; n < 30; n++) {
+    const start = performance.now()
+    slowFib(n)
+    if (performance.now() - start >= targetMs) {
+      return n
+    }
+  }
+  return 30
+}
+
+function SlowItem({promise, waste}: {promise: ObservablePromise<number>; waste: number}) {
+  const value = use(promise)
+  slowFib(waste)
+  return <i>{value}</i>
+}
+
+// `memo` is load-bearing (per react.dev's useDeferredValue guidance): without
+// it the sync store pass would re-render the slow items anyway (with the old
+// promise), defeating the deferral.
+const SlowList = memo(function SlowList({
+  promise,
+  waste,
+}: {
+  promise: ObservablePromise<number>
+  waste: number
+}) {
+  return (
+    <span data-testid="slow">
+      {Array.from({length: SLOW_ITEMS}, (_, i) => (
+        <SlowItem key={i} promise={promise} waste={waste} />
+      ))}
+    </span>
+  )
+})
+
+function DeferredSection({promise, waste}: {promise: ObservablePromise<number>; waste: number}) {
+  const deferred = useDeferredValue(promise)
+  return <SlowList promise={deferred} waste={waste} />
+}
+
+function InterruptibleApp({count$, waste}: {count$: BehaviorSubject<number>; waste: number}) {
+  const promise = useObservablePromise(count$)
+  const immediate = use(promise)
+  const [urgent, setUrgent] = useState(0)
+  return (
+    <>
+      <button type="button" onClick={() => setUrgent((n) => n + 1)}>
+        urgent
+      </button>
+      <span data-testid="immediate">{immediate}</span>
+      <span data-testid="urgent">{urgent}</span>
+      <DeferredSection promise={promise} waste={waste} />
+    </>
+  )
+}
+
+test('userland useDeferredValue(promise) restores time slicing for emission-driven updates', async () => {
+  // ≥4ms per item × 25 items ⇒ ≥100ms of deferred render work, sliced into
+  // many ~5ms scheduler chunks with yields in between.
+  const waste = calibrateWaste(4)
+  const count$ = new BehaviorSubject(0)
+
+  // act() flushes sync and deferred work together, hiding exactly the
+  // interleaving this test observes — so run without the act environment,
+  // driving a manual createRoot and sampling the DOM between event-loop turns.
+  const actEnv = globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}
+  const prevActEnv = actEnv.IS_REACT_ACT_ENVIRONMENT
+  actEnv.IS_REACT_ACT_ENVIRONMENT = false
+  const container = document.body.appendChild(document.createElement('div'))
+  const root = createRoot(container)
+  const read = (id: string) => container.querySelector(`[data-testid="${id}"]`)?.textContent
+
+  try {
+    root.render(<InterruptibleApp count$={count$} waste={waste} />)
+    await until(() => read('slow') === '0'.repeat(SLOW_ITEMS))
+    expect(read('immediate')).toBe('0')
+
+    // An emission from outside React: the uSES notification renders the app at
+    // sync priority (flushed in React's next immediate task), but
+    // useDeferredValue keeps the memoized slow subtree on the OLD promise —
+    // the expensive re-render is spawned on the deferred lane instead. Poll
+    // for the sync commit; at the first moment it is observable, the ≥100ms
+    // deferred pass cannot have committed, and both reads below happen in the
+    // same JS turn, which rendering cannot interleave.
+    count$.next(1)
+    await until(() => read('immediate') === '1', 2000, 5)
+    expect(read('slow')).toBe('0'.repeat(SLOW_ITEMS))
+
+    // Let the deferred render chew through a few 5ms slices, then interrupt it
+    // with an urgent update. This timer firing at all — and the click handler
+    // running — already proves the deferred render yields to the event loop
+    // (jsdom is single-threaded); the urgent commit landing while the slow
+    // subtree still shows old values proves it preempts the deferred pass.
+    await wait(10)
+    expect(read('slow')).toBe('0'.repeat(SLOW_ITEMS))
+    container.querySelector('button')!.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+    await until(() => read('urgent') === '1', 2000, 5)
+    expect(read('slow')).toBe('0'.repeat(SLOW_ITEMS))
+
+    // The interrupted deferred render restarts and converges to the emission.
+    await until(() => read('slow') === '1'.repeat(SLOW_ITEMS))
+    expect(read('immediate')).toBe('1')
+    expect(read('urgent')).toBe('1')
+  } finally {
+    actEnv.IS_REACT_ACT_ENVIRONMENT = prevActEnv
+    root.unmount()
+    container.remove()
+  }
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
@@ -1,0 +1,104 @@
+import {act, render, screen} from '@testing-library/react'
+import {Suspense, use, type ReactNode} from 'react'
+import {defer, from, Observable, of} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {preloadObservablePromise, useObservablePromise} from '../useObservablePromise'
+
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+test('sync termination does not leave a poisoned cache entry', async () => {
+  const observable = of('sync')
+
+  function Child() {
+    const value = use(useObservablePromise(observable, {ttl: 20}))
+    return <div data-testid="v">{value}</div>
+  }
+
+  const {unmount} = await renderAsync(
+    <Suspense fallback={<div>loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+  expect(screen.getByTestId('v').textContent).toBe('sync')
+  unmount()
+  await wait(40)
+
+  // Remount after eviction should succeed (fresh subscription), not replay a
+  // stale error or hang.
+  await renderAsync(
+    <Suspense fallback={<div>loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+  expect(screen.getByTestId('v').textContent).toBe('sync')
+})
+
+test('preloaded-never-consumed entry is torn down after ttl', async () => {
+  let active = 0
+  const observable = new Observable<string>((subscriber) => {
+    active++
+    subscriber.next('p')
+    // Keep the source open so teardown is observable via the unsubscribe hook.
+    return () => {
+      active--
+    }
+  })
+
+  preloadObservablePromise(observable, {ttl: 40})
+  expect(active).toBe(1)
+  await wait(70)
+  expect(active).toBe(0)
+})
+
+test('unmount after async settle allows remount after ttl to refetch', async () => {
+  let subscriptions = 0
+  const resolvers: Array<(value: string) => void> = []
+  const observable = defer(() => {
+    subscriptions++
+    return from(
+      new Promise<string>((r) => {
+        resolvers.push(r)
+      }),
+    )
+  })
+
+  function Child() {
+    const value = use(useObservablePromise(observable, {ttl: 40}))
+    return <div data-testid="v">{value}</div>
+  }
+
+  const {unmount} = await renderAsync(
+    <Suspense fallback={<div>loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+  await act(async () => {
+    resolvers[0]!('one')
+  })
+  expect(screen.getByTestId('v').textContent).toBe('one')
+  unmount()
+  await wait(70)
+
+  await renderAsync(
+    <Suspense fallback={<div data-testid="fallback">loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(subscriptions).toBe(2)
+  await act(async () => {
+    resolvers[1]!('two')
+  })
+  expect(screen.getByTestId('v').textContent).toBe('two')
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
@@ -17,6 +17,23 @@ function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+async function forceGC() {
+  // Exposed by `--expose-gc`, passed to the worker processes via `execArgv` in vitest.config.ts.
+  const {gc} = globalThis as {gc?: () => void}
+  if (typeof gc !== 'function') {
+    throw new TypeError(
+      'Expected `globalThis.gc` to be available — is `--expose-gc` missing from `execArgv` in vitest.config.ts?',
+    )
+  }
+  // A WeakRef target is kept alive until the end of the job it was created/dereferenced in, and a single
+  // pass isn't always enough to collect the whole graph, so yield to the macrotask queue between passes.
+  for (let i = 0; i < 5; i++) {
+    // oxlint-disable-next-line no-await-in-loop -- GC passes must run sequentially
+    await wait(0)
+    gc()
+  }
+}
+
 test('sync termination does not leave a poisoned cache entry', async () => {
   const observable = of('sync')
 
@@ -59,6 +76,62 @@ test('preloaded-never-consumed entry is torn down after ttl', async () => {
   expect(active).toBe(1)
   await wait(70)
   expect(active).toBe(0)
+})
+
+test('releases the settled value and promise after unmount and ttl expiry', async () => {
+  let valueRef: WeakRef<object> | undefined
+  const promiseRefs: WeakRef<object>[] = []
+  // Long-lived source (as if declared at module scope). It emits a fresh
+  // payload object per subscription and completes synchronously.
+  const source = defer(() => {
+    const value = {payload: 'x'.repeat(1024)}
+    valueRef = new WeakRef(value)
+    return of(value)
+  })
+
+  function Child() {
+    const promise = useObservablePromise(source, {ttl: 20})
+    promiseRefs.push(new WeakRef(promise))
+    return <>{use(promise).payload.length}</>
+  }
+
+  const {unmount} = await renderAsync(
+    <Suspense fallback={null}>
+      <Child />
+    </Suspense>,
+  )
+  unmount()
+  // Let the eviction timer fire, releasing the cache entry (which retains both
+  // the instrumented promise and, through it, the settled value).
+  await wait(50)
+
+  await forceGC()
+
+  expect(valueRef!.deref()).toBeUndefined()
+  expect(promiseRefs.length).toBeGreaterThan(0)
+  for (const promiseRef of promiseRefs) {
+    expect(promiseRef.deref()).toBeUndefined()
+  }
+  // Keep the source — the WeakMap key — strongly reachable across the GC above, so the value can
+  // only have been released through eviction, not by the key getting collected.
+  expect(source).toBeInstanceOf(Observable)
+})
+
+test('releases a preloaded-never-consumed value after ttl expiry', async () => {
+  let valueRef: WeakRef<object> | undefined
+  const source = defer(() => {
+    const value = {payload: 'x'.repeat(1024)}
+    valueRef = new WeakRef(value)
+    return of(value)
+  })
+
+  void preloadObservablePromise(source, {ttl: 20})
+  await wait(50)
+
+  await forceGC()
+
+  expect(valueRef!.deref()).toBeUndefined()
+  expect(source).toBeInstanceOf(Observable)
 })
 
 test('unmount after async settle allows remount after ttl to refetch', async () => {

--- a/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.leaks.test.tsx
@@ -55,7 +55,7 @@ test('preloaded-never-consumed entry is torn down after ttl', async () => {
     }
   })
 
-  preloadObservablePromise(observable, {ttl: 40})
+  void preloadObservablePromise(observable, {ttl: 40})
   expect(active).toBe(1)
   await wait(70)
   expect(active).toBe(0)

--- a/packages/react-rx/src/__tests__/useObservablePromise.ssr.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.ssr.test.tsx
@@ -1,0 +1,66 @@
+import {Suspense, use} from 'react'
+import {renderToString} from 'react-dom/server'
+import {defer, from, of} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservablePromise} from '../useObservablePromise'
+
+test('renderToString shows the Suspense fallback for a pending promise', () => {
+  const observable = defer(
+    () =>
+      new Promise<string>(() => {
+        /* never resolves during SSR */
+      }),
+  )
+
+  function Child() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  const html = renderToString(
+    <Suspense fallback={<div data-testid="fallback">loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+
+  expect(html).toContain('loading')
+  expect(html).not.toContain('data-testid="value"')
+})
+
+test('renderToString with a sync observable renders the fulfilled value', () => {
+  const observable = of('ssr-sync')
+
+  function Child() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  const html = renderToString(
+    <Suspense fallback={<div>loading</div>}>
+      <Child />
+    </Suspense>,
+  )
+
+  expect(html).toContain('ssr-sync')
+  expect(html).not.toContain('loading')
+})
+
+test('getServerSnapshot is provided (no uSES missing-server-snapshot error)', () => {
+  const observable = from(['server'])
+
+  function Child() {
+    // Calling the hook during SSR exercises getServerSnapshot.
+    const promise = useObservablePromise(observable)
+    const value = use(promise)
+    return <span>{value}</span>
+  }
+
+  expect(() =>
+    renderToString(
+      <Suspense fallback={<div>loading</div>}>
+        <Child />
+      </Suspense>,
+    ),
+  ).not.toThrow()
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.strictmode.test.tsx
@@ -1,0 +1,74 @@
+import {act, render, screen, waitFor} from '@testing-library/react'
+import {StrictMode, Suspense, use, type ReactNode} from 'react'
+import {defer, from, Observable} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservablePromise} from '../useObservablePromise'
+
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+test('StrictMode double-mount does not double-subscribe beyond the share contract', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  function Child() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <StrictMode>
+      <Suspense fallback={<div>loading</div>}>
+        <Child />
+      </Suspense>
+    </StrictMode>,
+  )
+
+  // Share + retention must collapse StrictMode double invoke to a single source sub.
+  expect(subscriptions).toBe(1)
+
+  await act(async () => {
+    resolve('strict')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('strict'))
+  expect(subscriptions).toBe(1)
+})
+
+test('StrictMode keeps a stable promise identity across double effects', async () => {
+  const identities: Promise<string>[] = []
+  const observable = new Observable<string>((subscriber) => {
+    subscriber.next('sync')
+  })
+
+  function Child() {
+    const p = useObservablePromise(observable)
+    identities.push(p)
+    return <div data-testid="value">{use(p)}</div>
+  }
+
+  await renderAsync(
+    <StrictMode>
+      <Suspense fallback={<div>loading</div>}>
+        <Child />
+      </Suspense>
+    </StrictMode>,
+  )
+
+  expect(screen.getByTestId('value').textContent).toBe('sync')
+  expect(identities.length).toBeGreaterThanOrEqual(1)
+  expect(new Set(identities).size).toBe(1)
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test-d.ts
@@ -1,0 +1,47 @@
+import {use} from 'react'
+import {of} from 'rxjs'
+import {expectTypeOf, test} from 'vitest'
+
+import {
+  preloadObservablePromise,
+  useObservablePromise,
+  type ObservablePromise,
+  type UseObservablePromiseOptions,
+} from '../useObservablePromise'
+
+test('useObservablePromise returns ObservablePromise<T> assignable to Promise<T>', () => {
+  const observable = of('foo')
+  const result = useObservablePromise(observable)
+  expectTypeOf(result).toEqualTypeOf<ObservablePromise<string>>()
+  expectTypeOf(result).toMatchTypeOf<Promise<string>>()
+})
+
+test('use(result) yields T', () => {
+  const promise = useObservablePromise(of(123))
+  const value = use(promise)
+  expectTypeOf(value).toEqualTypeOf<number>()
+})
+
+test('status discriminant narrows value and reason', () => {
+  const promise = useObservablePromise(of('x'))
+  if (promise.status === 'fulfilled') {
+    expectTypeOf(promise.value).toEqualTypeOf<string>()
+  }
+  if (promise.status === 'rejected') {
+    expectTypeOf(promise.reason).toEqualTypeOf<unknown>()
+  }
+  if (promise.status === 'pending') {
+    // @ts-expect-error pending promises have no value
+    expectTypeOf(promise.value).toEqualTypeOf<string>()
+  }
+})
+
+test('options accept disabled and ttl', () => {
+  const options: UseObservablePromiseOptions = {disabled: true, ttl: 1000}
+  useObservablePromise(of(1), options)
+})
+
+test('preloadObservablePromise returns ObservablePromise<T>', () => {
+  const result = preloadObservablePromise(of('pre'))
+  expectTypeOf(result).toEqualTypeOf<ObservablePromise<string>>()
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test-d.ts
@@ -13,7 +13,7 @@ test('useObservablePromise returns ObservablePromise<T> assignable to Promise<T>
   const observable = of('foo')
   const result = useObservablePromise(observable)
   expectTypeOf(result).toEqualTypeOf<ObservablePromise<string>>()
-  expectTypeOf(result).toMatchTypeOf<Promise<string>>()
+  expectTypeOf<ObservablePromise<string>>().toExtend<Promise<string>>()
 })
 
 test('use(result) yields T', () => {
@@ -38,7 +38,7 @@ test('status discriminant narrows value and reason', () => {
 
 test('options accept disabled and ttl', () => {
   const options: UseObservablePromiseOptions = {disabled: true, ttl: 1000}
-  useObservablePromise(of(1), options)
+  void useObservablePromise(of(1), options)
 })
 
 test('preloadObservablePromise returns ObservablePromise<T>', () => {

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -432,6 +432,52 @@ test('remount after ttl expiry refetches', async () => {
   await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('second'))
 })
 
+test('extending ttl after unmount keeps a long-lived source connected for the new retention', async () => {
+  const subject = new Subject<string>()
+  let active = 0
+  const observable = new Observable<string>((subscriber) => {
+    active++
+    const sub = subject.subscribe(subscriber)
+    return () => {
+      active--
+      sub.unsubscribe()
+    }
+  })
+
+  function Parent() {
+    const p = useObservablePromise(observable, {ttl: 40})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  const {unmount} = await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('one')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
+  expect(active).toBe(1)
+  unmount()
+  expect(active).toBe(1) // share grace still holding the connection
+
+  // Extend retention past the original 40ms grace while the disconnect timer
+  // from the short ttl is already running. Without bouncing share's reset,
+  // the connection would drop at ~40ms and this emission would be lost.
+  void preloadObservablePromise(observable, {ttl: 200})
+  await wait(80)
+  expect(active).toBe(1)
+
+  await act(async () => {
+    subject.next('two')
+  })
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('two')
+  expect(active).toBe(1)
+})
+
 test('observable swap re-suspends; useDeferredValue keeps previous content', async () => {
   let resolveA!: (value: string) => void
   let resolveB!: (value: string) => void

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -478,6 +478,93 @@ test('extending ttl after unmount keeps a long-lived source connected for the ne
   expect(active).toBe(1)
 })
 
+test('same-ttl preload after unmount renews share grace for long-lived sources', async () => {
+  const subject = new Subject<string>()
+  let active = 0
+  const observable = new Observable<string>((subscriber) => {
+    active++
+    const sub = subject.subscribe(subscriber)
+    return () => {
+      active--
+      sub.unsubscribe()
+    }
+  })
+
+  function Parent() {
+    const p = useObservablePromise(observable, {ttl: 40})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  const {unmount} = await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('one')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
+  unmount()
+
+  // Still inside the original 40ms grace: renew with the same ttl. Without a
+  // share bounce the disconnect still fires at unmount+40ms while eviction is
+  // pushed to touch+40ms — emissions in that gap are lost.
+  await wait(20)
+  void preloadObservablePromise(observable, {ttl: 40})
+  await wait(30) // ~50ms after unmount, ~30ms after renew — only valid if bounced
+  expect(active).toBe(1)
+
+  await act(async () => {
+    subject.next('two')
+  })
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('two')
+})
+
+test('settled entry is evicted after one retention window, not two', async () => {
+  const subject = new Subject<string>()
+  let active = 0
+  const observable = new Observable<string>((subscriber) => {
+    active++
+    const sub = subject.subscribe(subscriber)
+    return () => {
+      active--
+      sub.unsubscribe()
+    }
+  })
+  let fallbackCount = 0
+
+  function Parent() {
+    const p = useObservablePromise(observable, {ttl: 40})
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  const {unmount} = await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('first')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('first'))
+  const fallbacksAfterFirst = fallbackCount
+  unmount()
+
+  // One retention window (+ slack). If finalize restarted eviction when share
+  // disconnected, the entry would still be cached until ~2×ttl and remount
+  // would reuse the fulfilled promise (no fallback).
+  await wait(70)
+
+  await renderAsync(<Parent />)
+  expect(fallbackCount).toBeGreaterThan(fallbacksAfterFirst)
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  await act(async () => {
+    subject.next('second')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('second'))
+})
+
 test('observable swap re-suspends; useDeferredValue keeps previous content', async () => {
   let resolveA!: (value: string) => void
   let resolveB!: (value: string) => void

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -1,0 +1,856 @@
+import {act, render, screen, waitFor} from '@testing-library/react'
+import {
+  Component,
+  Suspense,
+  use,
+  useDeferredValue,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  BehaviorSubject,
+  defer,
+  EMPTY,
+  EmptyError,
+  from,
+  NEVER,
+  Observable,
+  of,
+  startWith,
+  Subject,
+  throwError,
+} from 'rxjs'
+import {expect, test, vi} from 'vitest'
+
+import {preloadObservablePromise, useObservablePromise} from '../useObservablePromise'
+
+/**
+ * Suspense recovery requires the initial render to be inside an awaited `act`.
+ * Otherwise React never attaches the wakeable ping and the boundary stays stuck.
+ */
+async function renderAsync(ui: ReactNode) {
+  let result!: ReturnType<typeof render>
+  await act(async () => {
+    result = render(ui)
+  })
+  return result
+}
+
+function Fallback({onRender}: {onRender?: () => void}) {
+  onRender?.()
+  return <div data-testid="fallback">loading</div>
+}
+
+function Reader({promise}: {promise: Promise<string>}) {
+  const value = use(promise)
+  return <div data-testid="value">{value}</div>
+}
+
+class TestErrorBoundary extends Component<
+  {children: ReactNode; onError?: (error: unknown) => void},
+  {error: unknown | null}
+> {
+  state: {error: unknown | null} = {error: null}
+  static getDerivedStateFromError(error: unknown) {
+    return {error}
+  }
+  componentDidCatch(error: unknown) {
+    this.props.onError?.(error)
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div data-testid="error">
+          {String((this.state.error as Error)?.message ?? this.state.error)}
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+test('suspends until the first emission, then shows data (fallback exactly once)', async () => {
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => from(promise))
+  let fallbackCount = 0
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(fallbackCount).toBeGreaterThanOrEqual(1)
+  const fallbacksAfterSuspend = fallbackCount
+
+  await act(async () => {
+    resolve('hello')
+    await promise
+  })
+
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('hello'))
+  expect(fallbackCount).toBe(fallbacksAfterSuspend)
+})
+
+test('sync sources never show a Suspense fallback', async () => {
+  const observable = of('sync')
+  let fallbackCount = 0
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('sync')
+  expect(fallbackCount).toBe(0)
+})
+
+test('startWith(placeholder) fulfills instantly with the placeholder (use useObservable for loading placeholders)', async () => {
+  // Use NEVER so only the startWith emission occurs (of()+startWith would sync-emit both).
+  const observable = NEVER.pipe(startWith('placeholder'))
+  let fallbackCount = 0
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  // firstValueFrom semantics: startWith is the first emission.
+  expect(screen.getByTestId('value').textContent).toBe('placeholder')
+  expect(fallbackCount).toBe(0)
+})
+
+test('promise identity is stable across re-renders while pending', async () => {
+  const subject = new Subject<string>()
+  const identities: Promise<string>[] = []
+
+  function Parent() {
+    const [, setTick] = useState(0)
+    const p = useObservablePromise(subject)
+    identities.push(p)
+    return (
+      <>
+        <button type="button" onClick={() => setTick((t) => t + 1)}>
+          rerender
+        </button>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(identities[0]?.status).toBe('pending')
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'rerender'}).click()
+  })
+
+  expect(identities.length).toBeGreaterThanOrEqual(2)
+  expect(identities[1]).toBe(identities[0])
+})
+
+test('first emission keeps promise identity; later emissions swap without re-activating fallback', async () => {
+  const subject = new Subject<string>()
+  let fallbackCount = 0
+  const identities: Promise<string>[] = []
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    identities.push(p)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  const pending = identities[0]!
+  const fallbacksAfterSuspend = fallbackCount
+
+  await act(async () => {
+    subject.next('one')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
+  expect(identities.at(-1)).toBe(pending)
+  expect(pending.status).toBe('fulfilled')
+  expect(fallbackCount).toBe(fallbacksAfterSuspend)
+
+  await act(async () => {
+    subject.next('two')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('two'))
+  expect(identities.at(-1)).not.toBe(pending)
+  expect(fallbackCount).toBe(fallbacksAfterSuspend)
+})
+
+test('Object.is-equal emission does not re-render the reader', async () => {
+  const subject = new Subject<string>()
+  let readerRenders = 0
+
+  function CountingReader({promise}: {promise: Promise<string>}) {
+    readerRenders++
+    const value = use(promise)
+    return <div data-testid="value">{value}</div>
+  }
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <CountingReader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('same')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('same'))
+  const rendersAfterFirst = readerRenders
+
+  await act(async () => {
+    subject.next('same')
+  })
+  expect(readerRenders).toBe(rendersAfterFirst)
+})
+
+test('multiple components share one source subscription and the same promise identity', async () => {
+  let subscriptions = 0
+  const subject = new Subject<string>()
+  const observable = new Observable<string>((subscriber) => {
+    subscriptions++
+    const sub = subject.subscribe(subscriber)
+    return () => sub.unsubscribe()
+  })
+
+  const promises: Promise<string>[] = []
+
+  function ChildA({promise}: {promise: Promise<string>}) {
+    return <div data-testid="a">{use(promise)}</div>
+  }
+  function ChildB({promise}: {promise: Promise<string>}) {
+    return <div data-testid="b">{use(promise)}</div>
+  }
+
+  function Parent() {
+    const p1 = useObservablePromise(observable)
+    const p2 = useObservablePromise(observable)
+    promises.push(p1, p2)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <ChildA promise={p1} />
+        <ChildB promise={p2} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(subscriptions).toBe(1)
+  expect(promises[0]).toBe(promises[1])
+
+  await act(async () => {
+    subject.next('shared')
+  })
+  await waitFor(() => {
+    expect(screen.getByTestId('a').textContent).toBe('shared')
+    expect(screen.getByTestId('b').textContent).toBe('shared')
+  })
+  expect(subscriptions).toBe(1)
+})
+
+test('error before first value is thrown to the nearest Error Boundary', async () => {
+  const observable = throwError(() => new Error('boom-before'))
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    return (
+      <TestErrorBoundary>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </TestErrorBoundary>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await waitFor(() => expect(screen.getByTestId('error').textContent).toContain('boom-before'))
+})
+
+test('error after a value is thrown to the nearest Error Boundary', async () => {
+  const subject = new Subject<string>()
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    return (
+      <TestErrorBoundary>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </TestErrorBoundary>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('ok')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('ok'))
+
+  await act(async () => {
+    subject.error(new Error('boom-after'))
+  })
+  await waitFor(() => expect(screen.getByTestId('error').textContent).toContain('boom-after'))
+})
+
+test('EMPTY rejects with EmptyError', async () => {
+  function Parent() {
+    const p = useObservablePromise(EMPTY)
+    return (
+      <TestErrorBoundary>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p as Promise<string>} />
+        </Suspense>
+      </TestErrorBoundary>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await waitFor(() => {
+    const text = screen.getByTestId('error').textContent ?? ''
+    expect(text.includes('EmptyError') || text.includes('no elements')).toBe(true)
+  })
+  expect(new EmptyError()).toBeInstanceOf(EmptyError)
+})
+
+test('complete after value keeps data; remount within retention reuses without refetch', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  function Parent() {
+    const p = useObservablePromise(observable, {ttl: 200})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  const {unmount} = await renderAsync(<Parent />)
+  expect(subscriptions).toBe(1)
+
+  await act(async () => {
+    resolve('cached')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('cached'))
+
+  unmount()
+
+  // Remount within TTL — should reuse settled promise, no new subscription.
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('cached')
+  expect(subscriptions).toBe(1)
+})
+
+test('remount after ttl expiry refetches', async () => {
+  let subscriptions = 0
+  const resolvers: Array<(value: string) => void> = []
+  const observable = defer(() => {
+    subscriptions++
+    return from(
+      new Promise<string>((r) => {
+        resolvers.push(r)
+      }),
+    )
+  })
+
+  function Parent() {
+    const p = useObservablePromise(observable, {ttl: 50})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  const {unmount} = await renderAsync(<Parent />)
+  await act(async () => {
+    resolvers[0]!('first')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('first'))
+  unmount()
+
+  await wait(80)
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(subscriptions).toBe(2)
+  await act(async () => {
+    resolvers[1]!('second')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('second'))
+})
+
+test('observable swap re-suspends; useDeferredValue keeps previous content', async () => {
+  let resolveA!: (value: string) => void
+  let resolveB!: (value: string) => void
+  const obsA = defer(
+    () =>
+      new Promise<string>((r) => {
+        resolveA = r
+      }),
+  )
+  const obsB = defer(
+    () =>
+      new Promise<string>((r) => {
+        resolveB = r
+      }),
+  )
+
+  function Parent() {
+    const [obs, setObs] = useState(obsA)
+    const deferred = useDeferredValue(obs)
+    const p = useObservablePromise(deferred)
+    return (
+      <>
+        <button type="button" onClick={() => setObs(obsB)}>
+          swap
+        </button>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    resolveA('A')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('A'))
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'swap'}).click()
+  })
+  // Deferred value still A while B loads — previous content stays.
+  expect(screen.getByTestId('value').textContent).toBe('A')
+
+  await act(async () => {
+    resolveB('B')
+    await wait(0)
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('B'))
+})
+
+test('single-component use(useObservablePromise(obs$)) performs exactly one source subscription', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  function Combined() {
+    const value = use(useObservablePromise(observable))
+    return <div data-testid="value">{value}</div>
+  }
+
+  await renderAsync(
+    <Suspense fallback={<Fallback />}>
+      <Combined />
+    </Suspense>,
+  )
+  expect(subscriptions).toBe(1)
+
+  await act(async () => {
+    resolve('once')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('once'))
+  expect(subscriptions).toBe(1)
+})
+
+test('disabled: true from mount performs zero source subscriptions', async () => {
+  let subscriptions = 0
+  const observable = new Observable<string>((subscriber) => {
+    subscriptions++
+    subscriber.next('x')
+  })
+
+  function Parent() {
+    const p = useObservablePromise(observable, {disabled: true})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <div data-testid="status">{p.status}</div>
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(subscriptions).toBe(0)
+  expect(screen.getByTestId('status').textContent).toBe('pending')
+})
+
+test('flipping disabled to false starts the fetch and resolves the same promise instance', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  const identities: Promise<string>[] = []
+  function TrackingParent() {
+    const [disabled, setDisabled] = useState(true)
+    const p = useObservablePromise(observable, {disabled})
+    identities.push(p)
+    return (
+      <>
+        <button type="button" onClick={() => setDisabled(false)}>
+          enable
+        </button>
+        <Suspense fallback={<Fallback />}>
+          {disabled ? <div data-testid="waiting">{p.status}</div> : <Reader promise={p} />}
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<TrackingParent />)
+  expect(subscriptions).toBe(0)
+  const pending = identities[0]!
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'enable'}).click()
+  })
+  expect(subscriptions).toBe(1)
+  expect(identities.at(-1)).toBe(pending)
+
+  await act(async () => {
+    resolve('enabled')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('enabled'))
+  expect(pending.status).toBe('fulfilled')
+})
+
+test('disabled component sharing a warmed entry gets the settled promise', async () => {
+  const observable = of('warm')
+
+  function Warmed() {
+    const p = useObservablePromise(observable)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  function Disabled() {
+    const p = useObservablePromise(observable, {disabled: true})
+    return <div data-testid="disabled-status">{p.status}:{(p as {value?: string}).value}</div>
+  }
+
+  await renderAsync(
+    <>
+      <Warmed />
+      <Disabled />
+    </>,
+  )
+  expect(screen.getByTestId('value').textContent).toBe('warm')
+  expect(screen.getByTestId('disabled-status').textContent).toBe('fulfilled:warm')
+})
+
+test('does not warn about uncached promises in DEV', async () => {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  const subject = new Subject<string>()
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('ok')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('ok'))
+
+  const uncached = spy.mock.calls.some((args) =>
+    String(args[0] ?? '').includes('uncached promise'),
+  )
+  expect(uncached).toBe(false)
+  spy.mockRestore()
+})
+
+test('preloadObservablePromise starts the fetch with nothing mounted', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  const preloaded = preloadObservablePromise(observable, {ttl: 200})
+  expect(subscriptions).toBe(1)
+  expect(preloaded.status).toBe('pending')
+
+  await act(async () => {
+    resolve('pre')
+    await promise
+  })
+  expect(preloaded.status).toBe('fulfilled')
+})
+
+test('mount mid-flight after preload shares the subscription (total = 1)', async () => {
+  let subscriptions = 0
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => {
+    subscriptions++
+    return from(promise)
+  })
+
+  const preloaded = preloadObservablePromise(observable, {ttl: 500})
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    expect(p).toBe(preloaded)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(subscriptions).toBe(1)
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+
+  await act(async () => {
+    resolve('shared-flight')
+    await promise
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('shared-flight'))
+  expect(subscriptions).toBe(1)
+})
+
+test('mount after preload settle within ttl renders with zero fallbacks', async () => {
+  let fallbackCount = 0
+  const observable = of('ready')
+  preloadObservablePromise(observable, {ttl: 500})
+
+  function Parent() {
+    const p = useObservablePromise(observable)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('ready')
+  expect(fallbackCount).toBe(0)
+})
+
+test('preload is idempotent', async () => {
+  const observable = of('x')
+  const a = preloadObservablePromise(observable)
+  const b = preloadObservablePromise(observable)
+  expect(a).toBe(b)
+})
+
+test('preloaded-never-consumed entry unsubscribes and evicts after ttl', async () => {
+  let active = 0
+  const subject = new BehaviorSubject('v')
+  const observable = new Observable<string>((subscriber) => {
+    active++
+    const sub = subject.subscribe(subscriber)
+    return () => {
+      active--
+      sub.unsubscribe()
+    }
+  })
+
+  preloadObservablePromise(observable, {ttl: 50})
+  expect(active).toBe(1)
+
+  await wait(80)
+  expect(active).toBe(0)
+
+  // After eviction, a new preload starts a fresh subscription.
+  preloadObservablePromise(observable, {ttl: 50})
+  expect(active).toBe(1)
+})
+
+test('BehaviorSubject is available synchronously without fallback', async () => {
+  const subject = new BehaviorSubject('bs')
+  let fallbackCount = 0
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    return (
+      <Suspense fallback={<Fallback onRender={() => fallbackCount++} />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('bs')
+  expect(fallbackCount).toBe(0)
+})
+
+test('rapid emissions while suspended converge to the latest value', async () => {
+  const subject = new Subject<string>()
+
+  function Parent() {
+    const p = useObservablePromise(subject)
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    subject.next('a')
+    subject.next('b')
+    subject.next('c')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('c'))
+})
+
+test('observable identity change without deferred value re-suspends', async () => {
+  let resolveA!: (value: string) => void
+  let resolveB!: (value: string) => void
+  const make = (assign: (r: (v: string) => void) => void) =>
+    defer(
+      () =>
+        new Promise<string>((r) => {
+          assign(r)
+        }),
+    )
+
+  const obsA = make((r) => {
+    resolveA = r
+  })
+  const obsB = make((r) => {
+    resolveB = r
+  })
+
+  function Parent() {
+    const [obs, setObs] = useState(obsA)
+    const p = useObservablePromise(obs)
+    return (
+      <>
+        <button type="button" onClick={() => setObs(obsB)}>
+          swap
+        </button>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  await act(async () => {
+    resolveA('A')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('A'))
+
+  await act(async () => {
+    screen.getByRole('button', {name: 'swap'}).click()
+  })
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+
+  await act(async () => {
+    resolveB('B')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('B'))
+})
+
+test('memoized observable is stable across parent re-renders', async () => {
+  let subscriptions = 0
+  const factory = () =>
+    new Observable<string>((subscriber) => {
+      subscriptions++
+      subscriber.next('m')
+    })
+
+  function Parent() {
+    const [, setTick] = useState(0)
+    const observable = useMemo(() => factory(), [])
+    const p = useObservablePromise(observable)
+    return (
+      <>
+        <button type="button" onClick={() => setTick((t) => t + 1)}>
+          tick
+        </button>
+        <Suspense fallback={<Fallback />}>
+          <Reader promise={p} />
+        </Suspense>
+      </>
+    )
+  }
+
+  await renderAsync(<Parent />)
+  expect(screen.getByTestId('value').textContent).toBe('m')
+  expect(subscriptions).toBe(1)
+  await act(async () => {
+    screen.getByRole('button', {name: 'tick'}).click()
+  })
+  expect(subscriptions).toBe(1)
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -521,6 +521,57 @@ test('same-ttl preload after unmount renews share grace for long-lived sources',
   expect(screen.getByTestId('value').textContent).toBe('two')
 })
 
+test('disabled re-renders do not renew grace — entry still evicts for later mounts', async () => {
+  let subscriptions = 0
+  const resolvers: Array<(value: string) => void> = []
+  const observable = defer(() => {
+    subscriptions++
+    return from(
+      new Promise<string>((r) => {
+        resolvers.push(r)
+      }),
+    )
+  })
+
+  function Active() {
+    const p = useObservablePromise(observable, {ttl: 40})
+    return (
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p} />
+      </Suspense>
+    )
+  }
+
+  function Disabled({tick}: {tick: number}) {
+    // Idle ensure on every render must not reset the eviction clock.
+    useObservablePromise(observable, {disabled: true, ttl: 40})
+    return <span data-testid="tick">{tick}</span>
+  }
+
+  const {unmount} = await renderAsync(<Active />)
+  await act(async () => {
+    resolvers[0]!('first')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('first'))
+  unmount()
+
+  const disabled = await renderAsync(<Disabled tick={0} />)
+  await act(async () => {
+    disabled.rerender(<Disabled tick={1} />)
+    disabled.rerender(<Disabled tick={2} />)
+  })
+  await wait(70)
+  disabled.unmount()
+
+  await renderAsync(<Active />)
+  expect(screen.getByTestId('fallback')).toBeTruthy()
+  expect(subscriptions).toBe(2)
+  await act(async () => {
+    resolvers[1]!('second')
+  })
+  await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('second'))
+})
+
 test('settled entry is evicted after one retention window, not two', async () => {
   const subject = new Subject<string>()
   let active = 0

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -210,11 +210,16 @@ test('first emission keeps promise identity; later emissions swap without re-act
   await renderAsync(<Parent />)
   const pending = identities[0]!
   const fallbacksAfterSuspend = fallbackCount
+  const parentRendersBeforeFirstEmission = identities.length
 
   await act(async () => {
     subject.next('one')
   })
   await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
+  // The first emission unblocks Suspense purely by resolving the promise in
+  // place: the store snapshot is unchanged, useSyncExternalStore bails out, and
+  // the parent does not re-render (per async-react discussion #3).
+  expect(identities.length).toBe(parentRendersBeforeFirstEmission)
   expect(identities.at(-1)).toBe(pending)
   expect(pending.status).toBe('fulfilled')
   expect(fallbackCount).toBe(fallbacksAfterSuspend)
@@ -223,6 +228,9 @@ test('first emission keeps promise identity; later emissions swap without re-act
     subject.next('two')
   })
   await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('two'))
+  // Later emissions DO notify the store (snapshot swapped to a pre-fulfilled
+  // promise) — the parent re-renders and the reader reads it synchronously.
+  expect(identities.length).toBeGreaterThan(parentRendersBeforeFirstEmission)
   expect(identities.at(-1)).not.toBe(pending)
   expect(fallbackCount).toBe(fallbacksAfterSuspend)
 })

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -544,7 +544,9 @@ test('disabled re-renders do not renew grace — entry still evicts for later mo
 
   function Disabled({tick}: {tick: number}) {
     // Idle ensure on every render must not reset the eviction clock.
-    useObservablePromise(observable, {disabled: true, ttl: 40})
+    // void: the return is an ObservablePromise (a Promise subclass); we only
+    // care that ensure runs, not that anything awaits the promise.
+    void useObservablePromise(observable, {disabled: true, ttl: 40})
     return <span data-testid="tick">{tick}</span>
   }
 

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -218,7 +218,7 @@ test('first emission keeps promise identity; later emissions swap without re-act
   await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
   // The first emission unblocks Suspense purely by resolving the promise in
   // place: the store snapshot is unchanged, useSyncExternalStore bails out, and
-  // the parent does not re-render (per async-react discussion #3).
+  // the parent does not re-render (per https://github.com/reactwg/async-react/discussions/3).
   expect(identities.length).toBe(parentRendersBeforeFirstEmission)
   expect(identities.at(-1)).toBe(pending)
   expect(pending.status).toBe('fulfilled')

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -12,7 +12,6 @@ import {
   BehaviorSubject,
   defer,
   EMPTY,
-  EmptyError,
   from,
   NEVER,
   Observable,
@@ -23,7 +22,11 @@ import {
 } from 'rxjs'
 import {expect, test, vi} from 'vitest'
 
-import {preloadObservablePromise, useObservablePromise} from '../useObservablePromise'
+import {
+  preloadObservablePromise,
+  useObservablePromise,
+  type ObservablePromise,
+} from '../useObservablePromise'
 
 /**
  * Suspense recovery requires the initial render to be inside an awaited `act`.
@@ -47,24 +50,39 @@ function Reader({promise}: {promise: Promise<string>}) {
   return <div data-testid="value">{value}</div>
 }
 
+function ReaderA({promise}: {promise: Promise<string>}) {
+  return <div data-testid="a">{use(promise)}</div>
+}
+
+function ReaderB({promise}: {promise: Promise<string>}) {
+  return <div data-testid="b">{use(promise)}</div>
+}
+
+function EmptyParent() {
+  const p = useObservablePromise(EMPTY)
+  return (
+    <TestErrorBoundary>
+      <Suspense fallback={<Fallback />}>
+        <Reader promise={p as Promise<string>} />
+      </Suspense>
+    </TestErrorBoundary>
+  )
+}
+
 class TestErrorBoundary extends Component<
-  {children: ReactNode; onError?: (error: unknown) => void},
-  {error: unknown | null}
+  {children: ReactNode; onError?: (error: Error) => void},
+  {error: Error | null}
 > {
-  state: {error: unknown | null} = {error: null}
-  static getDerivedStateFromError(error: unknown) {
+  override state: {error: Error | null} = {error: null}
+  static getDerivedStateFromError(error: Error) {
     return {error}
   }
-  componentDidCatch(error: unknown) {
+  override componentDidCatch(error: Error) {
     this.props.onError?.(error)
   }
-  render() {
+  override render() {
     if (this.state.error) {
-      return (
-        <div data-testid="error">
-          {String((this.state.error as Error)?.message ?? this.state.error)}
-        </div>
-      )
+      return <div data-testid="error">{this.state.error.message}</div>
     }
     return this.props.children
   }
@@ -145,7 +163,7 @@ test('startWith(placeholder) fulfills instantly with the placeholder (use useObs
 
 test('promise identity is stable across re-renders while pending', async () => {
   const subject = new Subject<string>()
-  const identities: Promise<string>[] = []
+  const identities: ObservablePromise<string>[] = []
 
   function Parent() {
     const [, setTick] = useState(0)
@@ -177,7 +195,7 @@ test('promise identity is stable across re-renders while pending', async () => {
 test('first emission keeps promise identity; later emissions swap without re-activating fallback', async () => {
   const subject = new Subject<string>()
   let fallbackCount = 0
-  const identities: Promise<string>[] = []
+  const identities: ObservablePromise<string>[] = []
 
   function Parent() {
     const p = useObservablePromise(subject)
@@ -250,14 +268,7 @@ test('multiple components share one source subscription and the same promise ide
     return () => sub.unsubscribe()
   })
 
-  const promises: Promise<string>[] = []
-
-  function ChildA({promise}: {promise: Promise<string>}) {
-    return <div data-testid="a">{use(promise)}</div>
-  }
-  function ChildB({promise}: {promise: Promise<string>}) {
-    return <div data-testid="b">{use(promise)}</div>
-  }
+  const promises: ObservablePromise<string>[] = []
 
   function Parent() {
     const p1 = useObservablePromise(observable)
@@ -265,8 +276,8 @@ test('multiple components share one source subscription and the same promise ide
     promises.push(p1, p2)
     return (
       <Suspense fallback={<Fallback />}>
-        <ChildA promise={p1} />
-        <ChildB promise={p2} />
+        <ReaderA promise={p1} />
+        <ReaderB promise={p2} />
       </Suspense>
     )
   }
@@ -330,23 +341,11 @@ test('error after a value is thrown to the nearest Error Boundary', async () => 
 })
 
 test('EMPTY rejects with EmptyError', async () => {
-  function Parent() {
-    const p = useObservablePromise(EMPTY)
-    return (
-      <TestErrorBoundary>
-        <Suspense fallback={<Fallback />}>
-          <Reader promise={p as Promise<string>} />
-        </Suspense>
-      </TestErrorBoundary>
-    )
-  }
-
-  await renderAsync(<Parent />)
+  await renderAsync(<EmptyParent />)
   await waitFor(() => {
     const text = screen.getByTestId('error').textContent ?? ''
     expect(text.includes('EmptyError') || text.includes('no elements')).toBe(true)
   })
-  expect(new EmptyError()).toBeInstanceOf(EmptyError)
 })
 
 test('complete after value keeps data; remount within retention reuses without refetch', async () => {
@@ -539,7 +538,7 @@ test('flipping disabled to false starts the fetch and resolves the same promise 
     return from(promise)
   })
 
-  const identities: Promise<string>[] = []
+  const identities: ObservablePromise<string>[] = []
   function TrackingParent() {
     const [disabled, setDisabled] = useState(true)
     const p = useObservablePromise(observable, {disabled})
@@ -687,7 +686,7 @@ test('mount mid-flight after preload shares the subscription (total = 1)', async
 test('mount after preload settle within ttl renders with zero fallbacks', async () => {
   let fallbackCount = 0
   const observable = of('ready')
-  preloadObservablePromise(observable, {ttl: 500})
+  void preloadObservablePromise(observable, {ttl: 500})
 
   function Parent() {
     const p = useObservablePromise(observable)
@@ -722,14 +721,14 @@ test('preloaded-never-consumed entry unsubscribes and evicts after ttl', async (
     }
   })
 
-  preloadObservablePromise(observable, {ttl: 50})
+  void preloadObservablePromise(observable, {ttl: 50})
   expect(active).toBe(1)
 
   await wait(80)
   expect(active).toBe(0)
 
   // After eviction, a new preload starts a fresh subscription.
-  preloadObservablePromise(observable, {ttl: 50})
+  void preloadObservablePromise(observable, {ttl: 50})
   expect(active).toBe(1)
 })
 
@@ -775,20 +774,18 @@ test('rapid emissions while suspended converge to the latest value', async () =>
 test('observable identity change without deferred value re-suspends', async () => {
   let resolveA!: (value: string) => void
   let resolveB!: (value: string) => void
-  const make = (assign: (r: (v: string) => void) => void) =>
-    defer(
-      () =>
-        new Promise<string>((r) => {
-          assign(r)
-        }),
-    )
-
-  const obsA = make((r) => {
-    resolveA = r
-  })
-  const obsB = make((r) => {
-    resolveB = r
-  })
+  const obsA = defer(
+    () =>
+      new Promise<string>((r) => {
+        resolveA = r
+      }),
+  )
+  const obsB = defer(
+    () =>
+      new Promise<string>((r) => {
+        resolveB = r
+      }),
+  )
 
   function Parent() {
     const [obs, setObs] = useState(obsA)

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -12,6 +12,7 @@ import {
   BehaviorSubject,
   defer,
   EMPTY,
+  EmptyError,
   from,
   NEVER,
   Observable,
@@ -58,10 +59,10 @@ function ReaderB({promise}: {promise: Promise<string>}) {
   return <div data-testid="b">{use(promise)}</div>
 }
 
-function EmptyParent() {
+function EmptyParent({onError}: {onError?: (error: Error) => void}) {
   const p = useObservablePromise(EMPTY)
   return (
-    <TestErrorBoundary>
+    <TestErrorBoundary onError={onError}>
       <Suspense fallback={<Fallback />}>
         <Reader promise={p as Promise<string>} />
       </Suspense>
@@ -348,12 +349,22 @@ test('error after a value is thrown to the nearest Error Boundary', async () => 
   await waitFor(() => expect(screen.getByTestId('error').textContent).toContain('boom-after'))
 })
 
-test('EMPTY rejects with EmptyError', async () => {
-  await renderAsync(<EmptyParent />)
+test('EMPTY rejects with the real RxJS EmptyError (instanceof holds)', async () => {
+  let captured: Error | undefined
+  await renderAsync(
+    <EmptyParent
+      onError={(error) => {
+        captured = error
+      }}
+    />,
+  )
   await waitFor(() => {
     const text = screen.getByTestId('error').textContent ?? ''
     expect(text.includes('EmptyError') || text.includes('no elements')).toBe(true)
   })
+  // firstValueFrom semantics: the rejection must be the exact RxJS EmptyError
+  // type so `instanceof EmptyError` checks in consumer code succeed.
+  expect(captured).toBeInstanceOf(EmptyError)
 })
 
 test('complete after value keeps data; remount within retention reuses without refetch', async () => {

--- a/packages/react-rx/src/index.ts
+++ b/packages/react-rx/src/index.ts
@@ -3,4 +3,8 @@
 export * from './types'
 export * from './useObservable'
 export * from './useObservableEvent'
+<<<<<<< HEAD
 export * from './useSyncObservable'
+=======
+export * from './useObservablePromise'
+>>>>>>> 421eb4c (feat(react-rx): add useObservablePromise and preloadObservablePromise)

--- a/packages/react-rx/src/index.ts
+++ b/packages/react-rx/src/index.ts
@@ -3,8 +3,5 @@
 export * from './types'
 export * from './useObservable'
 export * from './useObservableEvent'
-<<<<<<< HEAD
-export * from './useSyncObservable'
-=======
 export * from './useObservablePromise'
->>>>>>> 421eb4c (feat(react-rx): add useObservablePromise and preloadObservablePromise)
+export * from './useSyncObservable'

--- a/packages/react-rx/src/observablePromise.ts
+++ b/packages/react-rx/src/observablePromise.ts
@@ -31,7 +31,7 @@ export class ObservablePromiseImpl<T> extends Promise<T> {
   #reject: (reason?: unknown) => void
 
   // Derived `.then()` chains should return plain Promises, not instrumented subclasses.
-  static get [Symbol.species]() {
+  static override get [Symbol.species]() {
     return Promise
   }
 
@@ -48,7 +48,7 @@ export class ObservablePromiseImpl<T> extends Promise<T> {
     // an error settles (e.g. preload that nobody mounts).
     // Use Promise.prototype.then — `this.then` would construct another subclass
     // instance via @@species and recurse forever.
-    Promise.prototype.then.call(this, noop, noop)
+    void Promise.prototype.then.call(this, noop, noop)
   }
 
   /** Fulfill a pending promise in place (stable identity for Suspense unblock). */
@@ -77,8 +77,8 @@ export class ObservablePromiseImpl<T> extends Promise<T> {
     return promise
   }
 
-  static rejected(reason: unknown): ObservablePromiseImpl<never> {
-    const promise = new ObservablePromiseImpl<never>()
+  static rejected<T = never>(reason: unknown): ObservablePromiseImpl<T> {
+    const promise = new ObservablePromiseImpl<T>()
     promise.rejectWith(reason)
     return promise
   }

--- a/packages/react-rx/src/observablePromise.ts
+++ b/packages/react-rx/src/observablePromise.ts
@@ -1,0 +1,90 @@
+/**
+ * A Promise instrumented for React's `use()` / Suspense protocol.
+ *
+ * React reads `status` / `value` / `reason` synchronously (see
+ * `trackUsedThenable` in facebook/react). When `status` is already set,
+ * React will not attach its own instrumentation — we own those fields.
+ *
+ * Implemented as a real `Promise` subclass (recommended in
+ * https://github.com/reactwg/async-react/discussions/3). Rejection handlers
+ * are attached via `Promise.prototype.then` to avoid subclass species
+ * recursion from `this.then(...)` inside the constructor.
+ */
+
+function noop() {}
+
+/** @public */
+export type ObservablePromise<T> = Promise<T> &
+  (
+    | {status: 'pending'}
+    | {status: 'fulfilled'; value: T}
+    | {status: 'rejected'; reason: unknown}
+  )
+
+/** @internal */
+export class ObservablePromiseImpl<T> extends Promise<T> {
+  status: 'pending' | 'fulfilled' | 'rejected' = 'pending'
+  value?: T
+  reason?: unknown
+
+  #resolve: (value: T | PromiseLike<T>) => void
+  #reject: (reason?: unknown) => void
+
+  // Derived `.then()` chains should return plain Promises, not instrumented subclasses.
+  static get [Symbol.species]() {
+    return Promise
+  }
+
+  constructor() {
+    let resolve!: (value: T | PromiseLike<T>) => void
+    let reject!: (reason?: unknown) => void
+    super((res, rej) => {
+      resolve = res
+      reject = rej
+    })
+    this.#resolve = resolve
+    this.#reject = reject
+    // Prevent unhandled-rejection noise if nothing consumes the promise before
+    // an error settles (e.g. preload that nobody mounts).
+    // Use Promise.prototype.then — `this.then` would construct another subclass
+    // instance via @@species and recurse forever.
+    Promise.prototype.then.call(this, noop, noop)
+  }
+
+  /** Fulfill a pending promise in place (stable identity for Suspense unblock). */
+  fulfill(value: T): void {
+    if (this.status !== 'pending') {
+      return
+    }
+    this.status = 'fulfilled'
+    this.value = value
+    this.#resolve(value)
+  }
+
+  /** Reject a pending promise in place. */
+  rejectWith(reason: unknown): void {
+    if (this.status !== 'pending') {
+      return
+    }
+    this.status = 'rejected'
+    this.reason = reason
+    this.#reject(reason)
+  }
+
+  static fulfilled<T>(value: T): ObservablePromiseImpl<T> {
+    const promise = new ObservablePromiseImpl<T>()
+    promise.fulfill(value)
+    return promise
+  }
+
+  static rejected(reason: unknown): ObservablePromiseImpl<never> {
+    const promise = new ObservablePromiseImpl<never>()
+    promise.rejectWith(reason)
+    return promise
+  }
+}
+
+/** @internal */
+export function asObservablePromise<T>(promise: ObservablePromiseImpl<T>): ObservablePromise<T> {
+  return promise as ObservablePromise<T>
+}

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -54,11 +54,16 @@ type Outcome<T> = {ok: true; value: T} | {ok: false; error: unknown}
  */
 export interface ObservablePromiseEntry<T> {
   /**
-   * Adopt `ttl` (entries keep the max across consumers; a pending eviction
-   * timer is re-armed so retention counts from the last touch) and optionally
-   * start the eager resolver subscription. Idempotent — safe on every render.
+   * Adopt `ttl` (entries keep the max across consumers) and optionally start
+   * the eager resolver subscription. Idempotent — safe on every render.
+   *
+   * Pass `renewGrace: true` only for intentional touches (e.g. preload): that
+   * re-arms the eviction/share grace window from now. Idle renders from mounted
+   * but non-subscribed consumers (`disabled`, hidden `<Activity>`) must omit it
+   * so parent re-renders cannot keep the entry alive forever — pinning already
+   * preserves the mounted value after a real eviction.
    */
-  ensure(ttl: number, startResolver: boolean): void
+  ensure(ttl: number, startResolver: boolean, renewGrace?: boolean): void
   getPromise(): ObservablePromise<T>
   subscribe(onStoreChange: () => void): () => void
 }
@@ -201,25 +206,16 @@ function createEntry<T>(source: Observable<T>): CacheEntry<T> {
   )
 
   entry.handle = {
-    ensure: (ttl, startResolver) => {
-      const previousRetentionMs = entry.retentionMs
+    ensure: (ttl, startResolver, renewGrace = false) => {
       entry.retentionMs = Math.max(entry.retentionMs, ttl)
-      // Retention counts from the last touch (and may have just been extended,
-      // e.g. a preload arriving while a hook-settled entry awaits eviction).
-      if (entry.evictionTimer !== null) {
+      // Only intentional touches (preload) renew the grace window. The hook
+      // calls ensure on every render — including disabled consumers and hidden
+      // <Activity> trees that have no live store subscription — and must not
+      // reset the ttl clock or bounce share, or the entry/connection can live
+      // forever. Pinning already keeps the mounted value after eviction.
+      if (renewGrace && entry.evictionTimer !== null) {
         scheduleEviction(entry as CacheEntry<unknown>)
-        // `share({resetOnRefCountZero})` already started a disconnect timer when
-        // refCount hit zero. Re-arming eviction alone does not cancel that timer.
-        // Bounce a no-op subscription so share cancels the pending reset and
-        // starts a fresh grace period aligned with the renewed retention —
-        // otherwise long-lived sources disconnect early and miss emissions.
-        // Bounce on ttl increase *or* an active fetch intent (`startResolver`),
-        // so same-ttl preloads/remounts renew the connection too; skip for
-        // disabled re-renders that only touch retention.
-        if (
-          !entry.sourceTerminated &&
-          (entry.retentionMs > previousRetentionMs || startResolver)
-        ) {
+        if (!entry.sourceTerminated) {
           entry.shared$.subscribe().unsubscribe()
         }
       }

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -43,6 +43,26 @@ class ObservableEmptyError extends Error {
 
 type Outcome<T> = {ok: true; value: T} | {ok: false; error: unknown}
 
+/**
+ * Stable accessor for one cache entry. `useObservablePromise` pins one of these
+ * per observable identity (via `useMemo`) so a component that is mounted but has
+ * no live store subscription — hidden `<Activity>` trees, `disabled` consumers —
+ * keeps reading its settled promise even after the shared entry is evicted from
+ * the cache by the ttl policy. Mirrors `useObservable`'s local-reference pattern.
+ *
+ * @internal
+ */
+export interface ObservablePromiseEntry<T> {
+  /**
+   * Adopt `ttl` (entries keep the max across consumers; a pending eviction
+   * timer is re-armed so retention counts from the last touch) and optionally
+   * start the eager resolver subscription. Idempotent — safe on every render.
+   */
+  ensure(ttl: number, startResolver: boolean): void
+  getPromise(): ObservablePromise<T>
+  subscribe(onStoreChange: () => void): () => void
+}
+
 interface CacheEntry<T> {
   /** Unique per entry; used to guard stale finalize/eviction against successors. */
   readonly token: object
@@ -56,6 +76,7 @@ interface CacheEntry<T> {
   shared$: Observable<void>
   resolverSub: Subscription | null
   evictionTimer: ReturnType<typeof setTimeout> | null
+  handle: ObservablePromiseEntry<T>
 }
 
 const cache = new WeakMap<Observable<unknown>, CacheEntry<unknown>>()
@@ -120,19 +141,22 @@ function settle<T>(entry: CacheEntry<T>, outcome: Outcome<T>): void {
   }
 }
 
-function createEntry<T>(source: Observable<T>, retentionMs: number): CacheEntry<T> {
+function createEntry<T>(source: Observable<T>): CacheEntry<T> {
   const token = {}
   const entry: CacheEntry<T> = {
     token,
     source,
     current: new ObservablePromiseImpl<T>(),
     settled: false,
-    retentionMs,
+    // Every consumer calls `ensure` right after get-or-create, which sets the
+    // real retention. No subscription can start before that.
+    retentionMs: 0,
     liveCount: 0,
     sourceTerminated: false,
     shared$: undefined as unknown as Observable<void>,
     resolverSub: null,
     evictionTimer: null,
+    handle: undefined as unknown as ObservablePromiseEntry<T>,
   }
 
   entry.shared$ = source.pipe(
@@ -166,6 +190,51 @@ function createEntry<T>(source: Observable<T>, retentionMs: number): CacheEntry<
     }),
   )
 
+  entry.handle = {
+    ensure: (ttl, startResolver) => {
+      entry.retentionMs = Math.max(entry.retentionMs, ttl)
+      // Retention counts from the last touch (and may have just been extended,
+      // e.g. a preload arriving while a hook-settled entry awaits eviction).
+      if (entry.evictionTimer !== null) {
+        scheduleEviction(entry as CacheEntry<unknown>)
+      }
+      if (startResolver) {
+        ensureResolver(entry)
+      }
+    },
+    getPromise: () => asObservablePromise(entry.current),
+    subscribe: (onStoreChange: () => void) => {
+      // A pinned entry may have been evicted while its component was mounted
+      // without a live subscription (hidden <Activity> beyond ttl). Re-register
+      // it so new consumers share it again while it has live subscribers.
+      if (!cache.has(source)) {
+        cache.set(source, entry as CacheEntry<unknown>)
+      }
+      entry.liveCount++
+      clearEvictionTimer(entry as CacheEntry<unknown>)
+
+      if (entry.sourceTerminated) {
+        // No further emissions possible — retain the settled promise without
+        // re-subscribing (avoids refetching completed cold sources within TTL).
+        return () => {
+          entry.liveCount--
+          if (entry.liveCount === 0 && entry.settled) {
+            scheduleEviction(entry as CacheEntry<unknown>)
+          }
+        }
+      }
+
+      const subscription = entry.shared$.subscribe(onStoreChange)
+      return () => {
+        subscription.unsubscribe()
+        entry.liveCount--
+        if (entry.liveCount === 0 && entry.settled) {
+          scheduleEviction(entry as CacheEntry<unknown>)
+        }
+      }
+    },
+  }
+
   return entry
 }
 
@@ -187,65 +256,20 @@ function ensureResolver<T>(entry: CacheEntry<T>): void {
 }
 
 /**
- * Get or create the cache entry for `source`. Optionally start the eager
- * resolver subscription (render-phase / preload fetching).
+ * Get or create the cache entry for `source` and return its stable handle.
+ * Consumers call `handle.ensure(...)` immediately after to apply their
+ * retention/fetch policy.
  *
  * @internal
  */
-export function getObservablePromiseEntry<T>(
-  source: Observable<T>,
-  options: {ttl: number; startResolver: boolean},
-): {
-  getPromise: () => ObservablePromise<T>
-  subscribe: (onStoreChange: () => void) => () => void
-} {
-  const {ttl, startResolver} = options
+export function getObservablePromiseEntry<T>(source: Observable<T>): ObservablePromiseEntry<T> {
   let entry = cache.get(source) as CacheEntry<T> | undefined
-
   if (!entry) {
-    entry = createEntry(source, ttl)
-    // Insert before starting the resolver: sync-terminating sources trigger
-    // finalize immediately and must find the entry to schedule eviction.
+    entry = createEntry(source)
+    // Insert before any subscription can start (via `ensure`): sync-terminating
+    // sources trigger finalize immediately and must find the entry in the cache
+    // to schedule eviction.
     cache.set(source, entry as CacheEntry<unknown>)
-    if (startResolver) {
-      ensureResolver(entry)
-    }
-  } else {
-    entry.retentionMs = Math.max(entry.retentionMs, ttl)
-    if (startResolver) {
-      ensureResolver(entry)
-    }
   }
-
-  // For sync sources the entry may already be settled (and possibly scheduled
-  // for eviction). Return the local reference regardless.
-  const resolved = entry
-
-  return {
-    getPromise: () => asObservablePromise(resolved.current),
-    subscribe: (onStoreChange: () => void) => {
-      resolved.liveCount++
-      clearEvictionTimer(resolved as CacheEntry<unknown>)
-
-      if (resolved.sourceTerminated) {
-        // No further emissions possible — retain the settled promise without
-        // re-subscribing (avoids refetching completed cold sources within TTL).
-        return () => {
-          resolved.liveCount--
-          if (resolved.liveCount === 0 && resolved.settled) {
-            scheduleEviction(resolved as CacheEntry<unknown>)
-          }
-        }
-      }
-
-      const subscription = resolved.shared$.subscribe(onStoreChange)
-      return () => {
-        subscription.unsubscribe()
-        resolved.liveCount--
-        if (resolved.liveCount === 0 && resolved.settled) {
-          scheduleEviction(resolved as CacheEntry<unknown>)
-        }
-      }
-    },
-  }
+  return entry.handle
 }

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -192,11 +192,22 @@ function createEntry<T>(source: Observable<T>): CacheEntry<T> {
 
   entry.handle = {
     ensure: (ttl, startResolver) => {
+      const previousRetentionMs = entry.retentionMs
       entry.retentionMs = Math.max(entry.retentionMs, ttl)
       // Retention counts from the last touch (and may have just been extended,
       // e.g. a preload arriving while a hook-settled entry awaits eviction).
       if (entry.evictionTimer !== null) {
         scheduleEviction(entry as CacheEntry<unknown>)
+        // `share({resetOnRefCountZero})` already started a disconnect timer with
+        // the *old* retention when refCount hit zero. Extending `retentionMs`
+        // alone does not cancel that timer. Bounce a no-op subscription so
+        // share cancels the pending reset and, on the immediate unsubscribe,
+        // starts a fresh grace period with the updated retention — otherwise
+        // long-lived sources disconnect early and miss emissions that should
+        // still update the cache. Terminated sources need no connection.
+        if (entry.retentionMs > previousRetentionMs && !entry.sourceTerminated) {
+          entry.shared$.subscribe().unsubscribe()
+        }
       }
       if (startResolver) {
         ensureResolver(entry)

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -1,6 +1,5 @@
 import {
   catchError,
-  EmptyError,
   finalize,
   map,
   type Observable,
@@ -30,6 +29,17 @@ export const DEFAULT_HOOK_TTL = 500
  * Longer than the hook default so a hover-warmed value survives until click/navigation.
  */
 export const DEFAULT_PRELOAD_TTL = 5000
+
+/**
+ * Mirrors RxJS `EmptyError` / `firstValueFrom` when a source completes without
+ * emitting. We avoid constructing RxJS's deprecated `EmptyError` class.
+ */
+export class ObservableEmptyError extends Error {
+  override name = 'EmptyError'
+  constructor() {
+    super('no elements in sequence')
+  }
+}
 
 type Outcome<T> = {ok: true; value: T} | {ok: false; error: unknown}
 
@@ -134,7 +144,7 @@ function createEntry<T>(source: Observable<T>, retentionMs: number): CacheEntry<
       },
       complete: () => {
         if (!entry.settled) {
-          settle(entry, {ok: false, error: new EmptyError()})
+          settle(entry, {ok: false, error: new ObservableEmptyError()})
         }
         entry.sourceTerminated = true
       },

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -1,5 +1,6 @@
 import {
   catchError,
+  EmptyError,
   finalize,
   map,
   type Observable,
@@ -31,14 +32,15 @@ export const DEFAULT_HOOK_TTL = 500
 export const DEFAULT_PRELOAD_TTL = 5000
 
 /**
- * Mirrors RxJS `EmptyError` / `firstValueFrom` when a source completes without
- * emitting. We avoid constructing RxJS's deprecated `EmptyError` class.
+ * Reject with the real RxJS `EmptyError` when a source completes without
+ * emitting, matching `firstValueFrom` so `instanceof EmptyError` holds for
+ * consumers. RxJS marks the constructor `@deprecated` ("internal implementation
+ * detail"), but `firstValueFrom`/`first`/`single` throw this exact type, so
+ * mirroring it is intentional here.
  */
-class ObservableEmptyError extends Error {
-  override name = 'EmptyError'
-  constructor() {
-    super('no elements in sequence')
-  }
+function createEmptyError(): EmptyError {
+  // oxlint-disable-next-line typescript/no-deprecated -- mirror firstValueFrom's thrown EmptyError so instanceof works
+  return new EmptyError()
 }
 
 type Outcome<T> = {ok: true; value: T} | {ok: false; error: unknown}
@@ -173,7 +175,7 @@ function createEntry<T>(source: Observable<T>): CacheEntry<T> {
       },
       complete: () => {
         if (!entry.settled) {
-          settle(entry, {ok: false, error: new ObservableEmptyError()})
+          settle(entry, {ok: false, error: createEmptyError()})
         }
         entry.sourceTerminated = true
       },

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -181,7 +181,17 @@ function createEntry<T>(source: Observable<T>): CacheEntry<T> {
       // be able to reconnect to long-lived sources (e.g. Subject / SSE).
       // Comparing `token` prevents teardown of a stale, already replaced entry
       // from deleting its successor.
-      if (cache.get(source)?.token === token && entry.liveCount === 0 && entry.settled) {
+      //
+      // Do NOT restart an already-pending eviction timer: unsubscribe/settle
+      // schedule eviction for `retentionMs` at the same moment share starts its
+      // disconnect grace. When that grace ends, finalize runs — restarting
+      // eviction here would double the documented ttl.
+      if (
+        cache.get(source)?.token === token &&
+        entry.liveCount === 0 &&
+        entry.settled &&
+        entry.evictionTimer === null
+      ) {
         scheduleEviction(entry as CacheEntry<unknown>)
       }
     }),
@@ -198,14 +208,18 @@ function createEntry<T>(source: Observable<T>): CacheEntry<T> {
       // e.g. a preload arriving while a hook-settled entry awaits eviction).
       if (entry.evictionTimer !== null) {
         scheduleEviction(entry as CacheEntry<unknown>)
-        // `share({resetOnRefCountZero})` already started a disconnect timer with
-        // the *old* retention when refCount hit zero. Extending `retentionMs`
-        // alone does not cancel that timer. Bounce a no-op subscription so
-        // share cancels the pending reset and, on the immediate unsubscribe,
-        // starts a fresh grace period with the updated retention — otherwise
-        // long-lived sources disconnect early and miss emissions that should
-        // still update the cache. Terminated sources need no connection.
-        if (entry.retentionMs > previousRetentionMs && !entry.sourceTerminated) {
+        // `share({resetOnRefCountZero})` already started a disconnect timer when
+        // refCount hit zero. Re-arming eviction alone does not cancel that timer.
+        // Bounce a no-op subscription so share cancels the pending reset and
+        // starts a fresh grace period aligned with the renewed retention —
+        // otherwise long-lived sources disconnect early and miss emissions.
+        // Bounce on ttl increase *or* an active fetch intent (`startResolver`),
+        // so same-ttl preloads/remounts renew the connection too; skip for
+        // disabled re-renders that only touch retention.
+        if (
+          !entry.sourceTerminated &&
+          (entry.retentionMs > previousRetentionMs || startResolver)
+        ) {
           entry.shared$.subscribe().unsubscribe()
         }
       }

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -1,0 +1,247 @@
+import {
+  catchError,
+  EmptyError,
+  finalize,
+  map,
+  type Observable,
+  type Subscription,
+  of,
+  share,
+  tap,
+  timer,
+} from 'rxjs'
+
+import {
+  asObservablePromise,
+  ObservablePromiseImpl,
+  type ObservablePromise,
+} from './observablePromise'
+
+/**
+ * Default retention (ms) when the hook does not pass `ttl`.
+ * Long enough to bridge suspend → Suspense retry → commit and StrictMode
+ * double effects, so the single-component `use(useObservablePromise(...))`
+ * pattern performs exactly one source subscription.
+ */
+export const DEFAULT_HOOK_TTL = 500
+
+/**
+ * Default retention (ms) for `preloadObservablePromise` when `ttl` is omitted.
+ * Longer than the hook default so a hover-warmed value survives until click/navigation.
+ */
+export const DEFAULT_PRELOAD_TTL = 5000
+
+type Outcome<T> = {ok: true; value: T} | {ok: false; error: unknown}
+
+interface CacheEntry<T> {
+  /** Unique per entry; used to guard stale finalize/eviction against successors. */
+  readonly token: object
+  source: Observable<T>
+  current: ObservablePromiseImpl<T>
+  settled: boolean
+  retentionMs: number
+  liveCount: number
+  /** True once the shared source connection has completed or errored. */
+  sourceTerminated: boolean
+  shared$: Observable<void>
+  resolverSub: Subscription | null
+  evictionTimer: ReturnType<typeof setTimeout> | null
+}
+
+const cache = new WeakMap<Observable<unknown>, CacheEntry<unknown>>()
+
+function clearEvictionTimer(entry: CacheEntry<unknown>): void {
+  if (entry.evictionTimer !== null) {
+    clearTimeout(entry.evictionTimer)
+    entry.evictionTimer = null
+  }
+}
+
+function scheduleEviction(entry: CacheEntry<unknown>): void {
+  clearEvictionTimer(entry)
+  entry.evictionTimer = setTimeout(() => {
+    entry.evictionTimer = null
+    if (entry.liveCount > 0) {
+      return
+    }
+    // Pending entries are never timed out — a suspended consumer may still be
+    // waiting on this promise with no live uSES subscriber yet.
+    if (!entry.settled) {
+      return
+    }
+    if (cache.get(entry.source) === entry) {
+      cache.delete(entry.source)
+    }
+    if (entry.resolverSub) {
+      entry.resolverSub.unsubscribe()
+      entry.resolverSub = null
+    }
+  }, entry.retentionMs)
+}
+
+function settle<T>(entry: CacheEntry<T>, outcome: Outcome<T>): void {
+  if (!entry.settled) {
+    entry.settled = true
+    if (outcome.ok) {
+      entry.current.fulfill(outcome.value)
+    } else {
+      entry.current.rejectWith(outcome.error)
+    }
+    // Resolver's job is done after first settle. Live subscribers (or share's
+    // resetOnRefCountZero retention) keep the connection alive afterwards.
+    if (entry.resolverSub) {
+      entry.resolverSub.unsubscribe()
+      entry.resolverSub = null
+    }
+    if (entry.liveCount === 0) {
+      scheduleEviction(entry as CacheEntry<unknown>)
+    }
+    return
+  }
+
+  // Subsequent emissions: swap to a new pre-settled promise (unless Object.is).
+  if (outcome.ok) {
+    if (entry.current.status === 'fulfilled' && Object.is(entry.current.value, outcome.value)) {
+      return
+    }
+    entry.current = ObservablePromiseImpl.fulfilled(outcome.value)
+  } else {
+    entry.current = ObservablePromiseImpl.rejected(outcome.error)
+  }
+}
+
+function createEntry<T>(source: Observable<T>, retentionMs: number): CacheEntry<T> {
+  const token = {}
+  const entry: CacheEntry<T> = {
+    token,
+    source,
+    current: new ObservablePromiseImpl<T>(),
+    settled: false,
+    retentionMs,
+    liveCount: 0,
+    sourceTerminated: false,
+    shared$: undefined as unknown as Observable<void>,
+    resolverSub: null,
+    evictionTimer: null,
+  }
+
+  entry.shared$ = source.pipe(
+    map((value): Outcome<T> => ({ok: true, value})),
+    catchError((error: unknown) => of({ok: false, error} satisfies Outcome<T>)),
+    tap({
+      next: (outcome) => {
+        settle(entry, outcome)
+      },
+      complete: () => {
+        if (!entry.settled) {
+          settle(entry, {ok: false, error: new EmptyError()})
+        }
+        entry.sourceTerminated = true
+      },
+    }),
+    // After settling, the pipe is only a notifier for useSyncExternalStore.
+    map(() => undefined as void),
+    finalize(() => {
+      // Do NOT set `sourceTerminated` here: finalize also runs when share resets
+      // after refcount zero, which is not source completion. Remount must still
+      // be able to reconnect to long-lived sources (e.g. Subject / SSE).
+      // Comparing `token` prevents teardown of a stale, already replaced entry
+      // from deleting its successor.
+      if (cache.get(source)?.token === token && entry.liveCount === 0 && entry.settled) {
+        scheduleEviction(entry as CacheEntry<unknown>)
+      }
+    }),
+    share({
+      resetOnRefCountZero: () => timer(entry.retentionMs),
+    }),
+  )
+
+  return entry
+}
+
+function ensureResolver<T>(entry: CacheEntry<T>): void {
+  if (entry.settled || entry.resolverSub) {
+    return
+  }
+  // Keep the shared connection alive until first settle. Settle happens in tap;
+  // this subscription exists purely for refcount / side-effect of starting the source.
+  //
+  // Sync emissions settle before `subscribe()` returns, so `entry.resolverSub` is
+  // still null inside `settle` — unsubscribe the local subscription in that case.
+  const subscription = entry.shared$.subscribe()
+  if (entry.settled) {
+    subscription.unsubscribe()
+  } else {
+    entry.resolverSub = subscription
+  }
+}
+
+/**
+ * Get or create the cache entry for `source`. Optionally start the eager
+ * resolver subscription (render-phase / preload fetching).
+ *
+ * @internal
+ */
+export function getObservablePromiseEntry<T>(
+  source: Observable<T>,
+  options: {ttl: number; startResolver: boolean},
+): {
+  getPromise: () => ObservablePromise<T>
+  subscribe: (onStoreChange: () => void) => () => void
+} {
+  const {ttl, startResolver} = options
+  let entry = cache.get(source) as CacheEntry<T> | undefined
+
+  if (!entry) {
+    entry = createEntry(source, ttl)
+    // Insert before starting the resolver: sync-terminating sources trigger
+    // finalize immediately and must find the entry to schedule eviction.
+    cache.set(source, entry as CacheEntry<unknown>)
+    if (startResolver) {
+      ensureResolver(entry)
+    }
+  } else {
+    entry.retentionMs = Math.max(entry.retentionMs, ttl)
+    if (startResolver) {
+      ensureResolver(entry)
+    }
+  }
+
+  // For sync sources the entry may already be settled (and possibly scheduled
+  // for eviction). Return the local reference regardless.
+  const resolved = entry
+
+  return {
+    getPromise: () => asObservablePromise(resolved.current),
+    subscribe: (onStoreChange: () => void) => {
+      resolved.liveCount++
+      clearEvictionTimer(resolved as CacheEntry<unknown>)
+
+      if (resolved.sourceTerminated) {
+        // No further emissions possible — retain the settled promise without
+        // re-subscribing (avoids refetching completed cold sources within TTL).
+        return () => {
+          resolved.liveCount--
+          if (resolved.liveCount === 0 && resolved.settled) {
+            scheduleEviction(resolved as CacheEntry<unknown>)
+          }
+        }
+      }
+
+      const subscription = resolved.shared$.subscribe(onStoreChange)
+      return () => {
+        subscription.unsubscribe()
+        resolved.liveCount--
+        if (resolved.liveCount === 0 && resolved.settled) {
+          scheduleEviction(resolved as CacheEntry<unknown>)
+        }
+      }
+    },
+  }
+}
+
+/** @internal — test helper */
+export function __resetObservablePromiseCacheForTests(): void {
+  // WeakMap has no clear; entries are keyed by caller-owned observables.
+  // Tests rely on fresh observable identities instead.
+}

--- a/packages/react-rx/src/observablePromiseCache.ts
+++ b/packages/react-rx/src/observablePromiseCache.ts
@@ -34,7 +34,7 @@ export const DEFAULT_PRELOAD_TTL = 5000
  * Mirrors RxJS `EmptyError` / `firstValueFrom` when a source completes without
  * emitting. We avoid constructing RxJS's deprecated `EmptyError` class.
  */
-export class ObservableEmptyError extends Error {
+class ObservableEmptyError extends Error {
   override name = 'EmptyError'
   constructor() {
     super('no elements in sequence')
@@ -248,10 +248,4 @@ export function getObservablePromiseEntry<T>(
       }
     },
   }
-}
-
-/** @internal — test helper */
-export function __resetObservablePromiseCacheForTests(): void {
-  // WeakMap has no clear; entries are keyed by caller-owned observables.
-  // Tests rely on fresh observable identities instead.
 }

--- a/packages/react-rx/src/useObservablePromise.ts
+++ b/packages/react-rx/src/useObservablePromise.ts
@@ -97,9 +97,13 @@ export function useObservablePromise<T>(
 
 /**
  * Warm the promise cache outside of rendering (e.g. `onMouseEnter`, route
- * loaders). Creates or reuses the cache entry, starts the source subscription,
- * and returns the same {@link ObservablePromise} the hook would return for
- * that observable. Not a hook — callable anywhere.
+ * loaders). Creates or reuses the cache entry, starts the source subscription
+ * immediately, and returns the same {@link ObservablePromise} the hook would
+ * return for that observable. Not a hook — callable anywhere.
+ *
+ * Pending entries are never timed out: a never-emitting source keeps the
+ * promise pending and the subscription alive until it settles. Bound hang
+ * risk with RxJS `timeout` (or cancel the source) when a preload can stall.
  *
  * @public
  */

--- a/packages/react-rx/src/useObservablePromise.ts
+++ b/packages/react-rx/src/useObservablePromise.ts
@@ -1,4 +1,4 @@
-import {useCallback, useSyncExternalStore} from 'react'
+import {useCallback, useMemo, useSyncExternalStore} from 'react'
 import {type Observable} from 'rxjs'
 
 import {type ObservablePromise} from './observablePromise'
@@ -6,6 +6,7 @@ import {
   DEFAULT_HOOK_TTL,
   DEFAULT_PRELOAD_TTL,
   getObservablePromiseEntry,
+  type ObservablePromiseEntry,
 } from './observablePromiseCache'
 
 const EMPTY_OPTIONS = {}
@@ -31,6 +32,10 @@ export interface UseObservablePromiseOptions {
    * without refetching, and how long the shared connection lingers before
    * teardown/eviction. The entry adopts the max `ttl` across all of its
    * consumers.
+   *
+   * Eviction only affects future consumers: components that are still mounted
+   * keep their entry pinned, so hiding a `<Activity>` tree longer than `ttl`
+   * does not drop the value it rendered.
    *
    * @defaultValue 500
    */
@@ -60,26 +65,32 @@ export function useObservablePromise<T>(
 ): ObservablePromise<T> {
   const {disabled = false, ttl = DEFAULT_HOOK_TTL} = options
 
-  // Render-phase: ensure the cache entry exists, adopt max ttl, and eagerly
-  // start fetching unless disabled (required for Activity pre-rendering).
-  getObservablePromiseEntry(observable, {ttl, startResolver: !disabled})
+  // Pin the cache entry for as long as this component renders this observable
+  // identity. A mounted component without a live store subscription (hidden
+  // <Activity> tree, disabled consumer) must keep reading its settled promise
+  // even if the shared entry is evicted after `ttl` — the same local-reference
+  // pattern as `useObservable`.
+  const entry: ObservablePromiseEntry<T> = useMemo(
+    () => getObservablePromiseEntry(observable),
+    [observable],
+  )
+
+  // Per-render policy on the pinned entry: adopt the max ttl and eagerly start
+  // fetching unless disabled (required for Activity pre-rendering, where
+  // effects never run). Idempotent.
+  entry.ensure(ttl, !disabled)
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
       if (disabled) {
         return () => {}
       }
-      return getObservablePromiseEntry(observable, {ttl, startResolver: false}).subscribe(
-        onStoreChange,
-      )
+      return entry.subscribe(onStoreChange)
     },
-    [observable, disabled, ttl],
+    [entry, disabled],
   )
 
-  const getSnapshot = useCallback(
-    () => getObservablePromiseEntry(observable, {ttl, startResolver: false}).getPromise(),
-    [observable, ttl],
-  )
+  const getSnapshot = useCallback(() => entry.getPromise(), [entry])
 
   return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }
@@ -97,7 +108,9 @@ export function preloadObservablePromise<T>(
   options: PreloadObservablePromiseOptions = EMPTY_OPTIONS,
 ): ObservablePromise<T> {
   const {ttl = DEFAULT_PRELOAD_TTL} = options
-  return getObservablePromiseEntry(observable, {ttl, startResolver: true}).getPromise()
+  const entry = getObservablePromiseEntry(observable)
+  entry.ensure(ttl, true)
+  return entry.getPromise()
 }
 
 export type {ObservablePromise} from './observablePromise'

--- a/packages/react-rx/src/useObservablePromise.ts
+++ b/packages/react-rx/src/useObservablePromise.ts
@@ -113,7 +113,7 @@ export function preloadObservablePromise<T>(
 ): ObservablePromise<T> {
   const {ttl = DEFAULT_PRELOAD_TTL} = options
   const entry = getObservablePromiseEntry(observable)
-  entry.ensure(ttl, true)
+  entry.ensure(ttl, true, true)
   return entry.getPromise()
 }
 

--- a/packages/react-rx/src/useObservablePromise.ts
+++ b/packages/react-rx/src/useObservablePromise.ts
@@ -1,0 +1,104 @@
+import {useCallback, useSyncExternalStore} from 'react'
+import {type Observable} from 'rxjs'
+
+import {type ObservablePromise} from './observablePromise'
+import {
+  DEFAULT_HOOK_TTL,
+  DEFAULT_PRELOAD_TTL,
+  getObservablePromiseEntry,
+} from './observablePromiseCache'
+
+const EMPTY_OPTIONS = {}
+
+/** @public */
+export interface UseObservablePromiseOptions {
+  /**
+   * When `true`, this component starts neither the eager render-phase source
+   * subscription nor the live store subscription — i.e. no data fetching on
+   * behalf of this component.
+   *
+   * Unlike {@link useObservable}'s `disabled` (which still runs a warm-up probe),
+   * this fully prevents fetching. The returned promise is the shared cache
+   * entry's current promise: it stays pending until another consumer or
+   * {@link preloadObservablePromise} starts the source, or this component
+   * re-renders with `disabled: false` — at which point the same pending
+   * promise resolves.
+   */
+  disabled?: boolean
+  /**
+   * Retention (ms) of the cache entry once it is settled and has no live
+   * subscribers: how long a settled value stays reusable by a later mount
+   * without refetching, and how long the shared connection lingers before
+   * teardown/eviction. The entry adopts the max `ttl` across all of its
+   * consumers.
+   *
+   * @defaultValue 500
+   */
+  ttl?: number
+}
+
+/** @public */
+export interface PreloadObservablePromiseOptions {
+  /**
+   * Retention (ms) for the preloaded cache entry when nothing consumes it.
+   *
+   * @defaultValue 5000
+   */
+  ttl?: number
+}
+
+/**
+ * Subscribe to an observable and return a `use()`-compatible promise that
+ * activates Suspense until the first emission, then updates synchronously for
+ * later emissions without re-suspending.
+ *
+ * @public
+ */
+export function useObservablePromise<T>(
+  observable: Observable<T>,
+  options: UseObservablePromiseOptions = EMPTY_OPTIONS,
+): ObservablePromise<T> {
+  const {disabled = false, ttl = DEFAULT_HOOK_TTL} = options
+
+  // Render-phase: ensure the cache entry exists, adopt max ttl, and eagerly
+  // start fetching unless disabled (required for Activity pre-rendering).
+  getObservablePromiseEntry(observable, {ttl, startResolver: !disabled})
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (disabled) {
+        return () => {}
+      }
+      return getObservablePromiseEntry(observable, {ttl, startResolver: false}).subscribe(
+        onStoreChange,
+      )
+    },
+    [observable, disabled, ttl],
+  )
+
+  const getSnapshot = useCallback(
+    () => getObservablePromiseEntry(observable, {ttl, startResolver: false}).getPromise(),
+    [observable, ttl],
+  )
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+}
+
+/**
+ * Warm the promise cache outside of rendering (e.g. `onMouseEnter`, route
+ * loaders). Creates or reuses the cache entry, starts the source subscription,
+ * and returns the same {@link ObservablePromise} the hook would return for
+ * that observable. Not a hook — callable anywhere.
+ *
+ * @public
+ */
+export function preloadObservablePromise<T>(
+  observable: Observable<T>,
+  options: PreloadObservablePromiseOptions = EMPTY_OPTIONS,
+): ObservablePromise<T> {
+  const {ttl = DEFAULT_PRELOAD_TTL} = options
+  return getObservablePromiseEntry(observable, {ttl, startResolver: true}).getPromise()
+}
+
+export type {ObservablePromise} from './observablePromise'
+export {DEFAULT_HOOK_TTL, DEFAULT_PRELOAD_TTL} from './observablePromiseCache'

--- a/website/src/content/examples/_meta.ts
+++ b/website/src/content/examples/_meta.ts
@@ -7,4 +7,6 @@ export default {
   'context': 'React context',
   'sync': 'Sync rendering',
   'suspense': 'Suspense & deferred values',
+  'data-fetching': 'Suspense data fetching',
+  'activity': 'Activity and preload',
 }

--- a/website/src/content/examples/activity.mdx
+++ b/website/src/content/examples/activity.mdx
@@ -1,0 +1,11 @@
+import Example from '@/examples/activity'
+
+# Activity and preload
+
+Compare three strategies for the same ~1s tab fetch:
+
+1. **No prefetch** — mount on click; Suspense fallback is visible
+2. **Hover preload** — `preloadObservablePromise` on `mouseenter` warms the cache
+3. **Activity pre-render** — hidden `<Activity>` starts `use(promise)` fetches up front
+
+<Example />

--- a/website/src/content/examples/data-fetching.mdx
+++ b/website/src/content/examples/data-fetching.mdx
@@ -1,0 +1,9 @@
+import Example from '@/examples/data-fetching'
+
+# Suspense data fetching
+
+`useObservablePromise` returns a promise for React's `use()`. The Suspense
+fallback shows until the first emission; later stream updates do not re-trigger
+it.
+
+<Example />

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -221,7 +221,7 @@ The `memo` is load-bearing: without it the subtree re-renders during the synchro
 
 **Preloading**
 
-Warm the cache outside of render (hover, route loaders) with `preloadObservablePromise`:
+Warm the cache outside of render (hover, route loaders) with `preloadObservablePromise`. Calling it starts the source subscription immediately. Pending entries are never timed out — if the observable never emits or completes, the promise stays pending and the subscription stays alive until it settles (or the process tears down). Bound hang risk with RxJS [`timeout`](https://rxjs.dev/api/operators/timeout) (or cancel the source) when the preload can stall:
 
 ```tsx
 import {preloadObservablePromise, useObservablePromise} from 'react-rx'

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -130,6 +130,126 @@ function SearchField() {
 }
 ```
 
+### useObservablePromise()
+
+Use this when you want **Suspense-powered data fetching** instead of tracking loading state in the stream.
+
+`useObservable` is built on `useSyncExternalStore`. That is great for live values, but it cannot activate a [`Suspense`](https://react.dev/reference/react/Suspense#what-activates-a-suspense-boundary) boundary, and React 19.2 [`Activity`](https://react.dev/reference/react/Activity#pre-rendering-content-thats-likely-to-become-visible) pre-rendering only fetches data read with `use(promise)`.
+
+`useObservablePromise` returns an instrumented Promise you pass to React's `use()`. The hook itself does **not** suspend — the consumer decides where the Suspense boundary lives:
+
+```tsx
+import {Suspense, use, useMemo} from 'react'
+import {useObservablePromise} from 'react-rx'
+import {fromFetch} from 'rxjs/fetch'
+
+function Users() {
+  const users$ = useMemo(
+    () =>
+      fromFetch('https://api.github.com/users?per_page=5', {
+        selector: (response) => response.json(),
+      }),
+    [],
+  )
+  const promise = useObservablePromise(users$)
+
+  return (
+    <Suspense fallback={<p>Loading users…</p>}>
+      <UsersList promise={promise} />
+    </Suspense>
+  )
+}
+
+function UsersList({promise}: {promise: Promise<unknown>}) {
+  const users = use(promise)
+  return <pre>{JSON.stringify(users, null, 2)}</pre>
+}
+```
+
+Prefer creating the promise in a parent that does **not** suspend (as above), so Suspense retries always see the same promise identity. The single-component form also works when the observable identity is stable across retries (module-level cache, or a shared `WeakMap` keyed by request):
+
+```tsx
+function UsersList({users$}) {
+  // `users$` must be referentially stable for the in-flight request
+  const users = use(useObservablePromise(users$))
+  return <pre>{JSON.stringify(users, null, 2)}</pre>
+}
+```
+
+**Semantics**
+
+- Suspends until the observable's **first** emission (`firstValueFrom` semantics).
+- Later emissions update the UI **without** re-showing the Suspense fallback.
+- Sync sources (`of`, `BehaviorSubject`, replayed `shareReplay`) never flash a fallback.
+- Errors reject the promise and surface through the nearest Error Boundary. Prefer `catchError` on the *inner* observable when you want graceful degradation instead of a boundary.
+- Completing without emitting rejects with RxJS `EmptyError`.
+- Swapping to a **different** observable returns a new pending promise, so the fallback shows again. To keep the previous content visible instead, change the observable inside [`startTransition`](https://react.dev/reference/react/startTransition) or read the promise through [`useDeferredValue`](https://react.dev/reference/react/useDeferredValue) — both also give you a staleness signal (`isPending`, or `deferredPromise !== promise`) to dim stale content while the new data loads.
+
+**Not for `startWith` placeholders.** Because the first emission unblocks Suspense, `startWith('loading')` fulfills immediately with `"loading"`. For placeholder / loading-value patterns, use `useObservable` instead.
+
+**Options**
+
+```ts
+useObservablePromise(observable$, {
+  disabled?: boolean // default false — when true, this component starts no fetch
+  ttl?: number // default 500 — retention (ms) after settle with no subscribers
+})
+```
+
+Unlike `useObservable`'s `disabled` (which still runs a warm-up probe), `disabled: true` here fully prevents fetching on behalf of this component. The returned promise is still the shared cache entry — a sibling or `preloadObservablePromise` can warm it.
+
+`ttl` controls how long a settled value stays reusable after unmount. Remount within the window reuses the promise (no refetch, no fallback). After it expires, the next mount refetches. Eviction only affects future consumers: components that are still mounted keep their value — hiding an `<Activity>` tree longer than `ttl` never drops what it already rendered.
+
+**Deferring expensive re-renders**
+
+Like every external-store subscription, emission-driven updates render at synchronous priority — React cannot time-slice them directly. If an emission re-renders something expensive, defer the promise itself and memoize the expensive subtree. The synchronous pass then skips the memoized subtree (it still sees the old promise), and its re-render happens at deferred priority: time-sliced, interruptible by urgent updates, and coalesced under rapid emissions.
+
+```tsx
+const BigChart = memo(function BigChart({promise}) {
+  const data = use(promise)
+  return <Chart data={data} />
+})
+
+function Dashboard({metrics$}) {
+  const promise = useObservablePromise(metrics$)
+  const deferredPromise = useDeferredValue(promise)
+  return <BigChart promise={deferredPromise} />
+}
+```
+
+The `memo` is load-bearing: without it the subtree re-renders during the synchronous pass anyway (with the old promise), defeating the deferral — see [deferring re-rendering for a part of the UI](https://react.dev/reference/react/useDeferredValue#deferring-re-rendering-for-a-part-of-the-ui). Swapped promises are always pre-settled, so the deferred subtree never suspends — it just lags by a paint under load. When the stream itself is too chatty, throttling in the pipe (`auditTime`, `throttleTime`) remains the RxJS-native complement.
+
+**Preloading**
+
+Warm the cache outside of render (hover, route loaders) with `preloadObservablePromise`:
+
+```tsx
+import {preloadObservablePromise, useObservablePromise} from 'react-rx'
+
+function TabButton({users$, onSelect}) {
+  return (
+    <button
+      type="button"
+      onMouseEnter={() => preloadObservablePromise(users$, {ttl: 5_000})}
+      onClick={onSelect}
+    >
+      Users
+    </button>
+  )
+}
+```
+
+**Which hook when?**
+
+| Need | Hook |
+| --- | --- |
+| Live values, timers, subjects, optional `initialValue` | `useObservable` |
+| Controlled inputs / synchronous store updates | `useSyncObservable` |
+| Async data + Suspense / Activity pre-render | `useObservablePromise` |
+| Event → observable pipelines | `useObservableEvent` |
+
+For cold observables you want to share across subscribers yourself, keep using RxJS `shareReplay({bufferSize: 1, refCount: true})` — the hook's `ttl` is a lightweight mount/unmount cache, not a full query cache.
+
 ### useObservableEvent()
 
 This creates an event handler that can be used to create an observable from events.

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -138,6 +138,8 @@ function Pre({promise}: {promise: Promise<unknown>}) {
 
 Warm the `useObservablePromise` cache outside of rendering (for example on `mouseenter` or in a route loader). Not a hook — callable anywhere. Returns the same promise instance the hook would return for that observable.
 
+Calling it starts the source subscription immediately. Pending entries are never timed out, so a never-emitting / hung observable keeps both the promise and the subscription alive until it settles. Prefer RxJS [`timeout`](https://rxjs.dev/api/operators/timeout) (or cancel the source) when a preload can stall.
+
 **Signature**
 
 ```ts

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -82,6 +82,73 @@ function SearchField() {
 }
 ```
 
+## useObservablePromise()
+
+A React hook that turns an observable into a `use()`-compatible promise for Suspense and Activity pre-rendering.
+
+**Signature**
+
+```ts
+function useObservablePromise<T>(
+  observable: Observable<T>,
+  options?: UseObservablePromiseOptions,
+): ObservablePromise<T>
+
+interface UseObservablePromiseOptions {
+  disabled?: boolean
+  ttl?: number
+}
+
+type ObservablePromise<T> = Promise<T> &
+  (
+    | {status: 'pending'}
+    | {status: 'fulfilled'; value: T}
+    | {status: 'rejected'; reason: unknown}
+  )
+```
+
+The hook does **not** suspend. Pass the returned promise to React's [`use`](https://react.dev/reference/react/use) inside a `<Suspense>` boundary. Suspends until the first emission; later emissions update without re-suspending. Errors reject the promise (Error Boundary). See the [guide](/guide) for `startWith` caveats, `disabled` / `ttl`, and when to prefer `useObservable`.
+
+**Example**
+
+```tsx
+import {Suspense, use, useMemo} from 'react'
+import {useObservablePromise} from 'react-rx'
+import {fromFetch} from 'rxjs/fetch'
+
+function Profile({url}: {url: string}) {
+  const data$ = useMemo(
+    () => fromFetch(url, {selector: (r) => r.json()}),
+    [url],
+  )
+  const promise = useObservablePromise(data$)
+  return (
+    <Suspense fallback="Loading…">
+      <Pre promise={promise} />
+    </Suspense>
+  )
+}
+
+function Pre({promise}: {promise: Promise<unknown>}) {
+  return <pre>{JSON.stringify(use(promise), null, 2)}</pre>
+}
+```
+
+## preloadObservablePromise()
+
+Warm the `useObservablePromise` cache outside of rendering (for example on `mouseenter` or in a route loader). Not a hook — callable anywhere. Returns the same promise instance the hook would return for that observable.
+
+**Signature**
+
+```ts
+function preloadObservablePromise<T>(
+  observable: Observable<T>,
+  options?: {ttl?: number},
+): ObservablePromise<T>
+```
+
+Default `ttl` is `5000` (longer than the hook default) so a hover-warmed value survives until click/navigation.
+
 ## useObservableEvent()
 
 A React hook that turns an event handler into an observable stream. Pass a function that receives an observable of events and returns an observable of side effects; the hook returns a stable callback you can attach to DOM or component event props.

--- a/website/src/examples/activity/App.tsx
+++ b/website/src/examples/activity/App.tsx
@@ -1,0 +1,89 @@
+import {Activity, Suspense, useMemo, useState} from 'react'
+import {preloadObservablePromise} from 'react-rx'
+
+import {fetchTab$} from './api'
+import TabPanel from './TabPanel'
+
+type Strategy = 'none' | 'preload' | 'activity'
+
+const TABS = ['Posts', 'Photos', 'Settings'] as const
+
+function TabButton({
+  tab,
+  active,
+  strategy,
+  onSelect,
+}: {
+  tab: (typeof TABS)[number]
+  active: boolean
+  strategy: Strategy
+  onSelect: () => void
+}) {
+  const data$ = useMemo(() => fetchTab$(tab), [tab])
+
+  return (
+    <button
+      type="button"
+      onMouseEnter={() => {
+        if (strategy === 'preload') {
+          preloadObservablePromise(data$, {ttl: 10_000})
+        }
+      }}
+      onClick={onSelect}
+      style={{fontWeight: active ? 700 : 400}}
+    >
+      {tab}
+    </button>
+  )
+}
+
+export default function App() {
+  const [strategy, setStrategy] = useState<Strategy>('none')
+  const [active, setActive] = useState<(typeof TABS)[number]>('Posts')
+
+  return (
+    <div style={{fontFamily: 'system-ui', padding: 16, maxWidth: 480}}>
+      <h2 style={{marginTop: 0}}>Prefetch strategies</h2>
+      <p style={{fontSize: 14}}>
+        Each tab fetch takes ~1s. Compare click-only loading vs hover preload vs
+        hidden <code>Activity</code> pre-render.
+      </p>
+
+      <label style={{display: 'block', marginBottom: 12}}>
+        Strategy:{' '}
+        <select
+          value={strategy}
+          onChange={(e) => setStrategy(e.target.value as Strategy)}
+        >
+          <option value="none">No prefetch (fetch on reveal)</option>
+          <option value="preload">Hover preload</option>
+          <option value="activity">Activity pre-render</option>
+        </select>
+      </label>
+
+      <div style={{display: 'flex', gap: 8, marginBottom: 16}}>
+        {TABS.map((tab) => (
+          <TabButton
+            key={tab}
+            tab={tab}
+            active={active === tab}
+            strategy={strategy}
+            onSelect={() => setActive(tab)}
+          />
+        ))}
+      </div>
+
+      <Suspense fallback={<p style={{opacity: 0.7}}>🌀 Loading…</p>}>
+        {strategy === 'activity' ? (
+          TABS.map((tab) => (
+            <Activity key={tab} mode={active === tab ? 'visible' : 'hidden'}>
+              <TabPanel tab={tab} />
+            </Activity>
+          ))
+        ) : (
+          <TabPanel tab={active} />
+        )}
+      </Suspense>
+    </div>
+  )
+}

--- a/website/src/examples/activity/App.tsx
+++ b/website/src/examples/activity/App.tsx
@@ -26,7 +26,7 @@ function TabButton({
       type="button"
       onMouseEnter={() => {
         if (strategy === 'preload') {
-          preloadObservablePromise(data$, {ttl: 10_000})
+          void preloadObservablePromise(data$, {ttl: 10_000})
         }
       }}
       onClick={onSelect}

--- a/website/src/examples/activity/TabPanel.tsx
+++ b/website/src/examples/activity/TabPanel.tsx
@@ -1,0 +1,17 @@
+import {use} from 'react'
+import {useObservablePromise} from 'react-rx'
+import {useMemo} from 'react'
+
+import {fetchTab$} from './api'
+
+export default function TabPanel({tab}: {tab: string}) {
+  const data$ = useMemo(() => fetchTab$(tab), [tab])
+  const data = use(useObservablePromise(data$))
+
+  return (
+    <div style={{padding: 12, border: '1px solid #ccc', borderRadius: 8}}>
+      <strong>{data.tab}</strong>
+      <p>{data.body}</p>
+    </div>
+  )
+}

--- a/website/src/examples/activity/api.ts
+++ b/website/src/examples/activity/api.ts
@@ -1,0 +1,20 @@
+import {map, type Observable, timer} from 'rxjs'
+
+const LATENCY_MS = 1000
+
+const cache = new Map<string, Observable<{tab: string; body: string}>>()
+
+/** Cold fetch-like source with visible artificial latency. Stable per tab id. */
+export function fetchTab$(tab: string): Observable<{tab: string; body: string}> {
+  let observable = cache.get(tab)
+  if (!observable) {
+    observable = timer(LATENCY_MS).pipe(
+      map(() => ({
+        tab,
+        body: `Content for “${tab}” loaded after ${LATENCY_MS}ms`,
+      })),
+    )
+    cache.set(tab, observable)
+  }
+  return observable
+}

--- a/website/src/examples/activity/index.tsx
+++ b/website/src/examples/activity/index.tsx
@@ -1,0 +1,14 @@
+import ExampleSandpack from '@/components/ExampleSandpack'
+import {readExample} from '@/utils/readExample'
+
+export default function Example() {
+  return (
+    <ExampleSandpack
+      files={{
+        '/App.tsx': readExample('activity', 'App.tsx'),
+        '/TabPanel.tsx': readExample('activity', 'TabPanel.tsx'),
+        '/api.ts': readExample('activity', 'api.ts'),
+      }}
+    />
+  )
+}

--- a/website/src/examples/data-fetching/DataFetchingExample.tsx
+++ b/website/src/examples/data-fetching/DataFetchingExample.tsx
@@ -1,0 +1,80 @@
+import {Suspense, use, useState} from 'react'
+import {useObservablePromise, type ObservablePromise} from 'react-rx'
+import {map, type Observable, timer} from 'rxjs'
+
+const LATENCY_MS = 800
+
+const userCache = new Map<string, Observable<{id: string; name: string; bio: string}>>()
+
+/** Stable per id so Suspense retries and remounts share one in-flight request. */
+function fetchUser$(id: string) {
+  let observable = userCache.get(id)
+  if (!observable) {
+    observable = timer(LATENCY_MS).pipe(
+      map(() => ({
+        id,
+        name: id === 'alpha' ? 'Ada Lovelace' : 'Grace Hopper',
+        bio: `Profile loaded for ${id}`,
+      })),
+    )
+    userCache.set(id, observable)
+  }
+  return observable
+}
+
+const clock$ = timer(0, 1000).pipe(
+  map((n) => `Tick ${n} — live updates skip the Suspense fallback`),
+)
+
+function Profile({
+  promise,
+}: {
+  promise: ObservablePromise<{id: string; name: string; bio: string}>
+}) {
+  const user = use(promise)
+  return (
+    <div>
+      <h3>{user.name}</h3>
+      <p>{user.bio}</p>
+    </div>
+  )
+}
+
+function LiveClock() {
+  const label = use(useObservablePromise(clock$))
+  return <p style={{fontSize: 14, opacity: 0.8}}>{label}</p>
+}
+
+export default function DataFetchingExample() {
+  const [id, setId] = useState('alpha')
+  // Create the promise in a parent that does not suspend, so Suspense retries
+  // always see the same promise identity (see React's use() caching guidance).
+  const promise = useObservablePromise(fetchUser$(id))
+
+  return (
+    <div style={{fontFamily: 'system-ui', padding: 16}}>
+      <p>
+        <button type="button" onClick={() => setId('alpha')}>
+          alpha
+        </button>{' '}
+        <button type="button" onClick={() => setId('beta')}>
+          beta
+        </button>
+      </p>
+      <Suspense
+        key={id}
+        fallback={<p style={{opacity: 0.7}}>Loading {id}…</p>}
+      >
+        <Profile promise={promise} />
+      </Suspense>
+      <hr style={{margin: '16px 0'}} />
+      <Suspense fallback={null}>
+        <LiveClock />
+      </Suspense>
+      <p style={{marginTop: 16, fontSize: 14, opacity: 0.75}}>
+        Switching profiles re-suspends (new observable). The clock updates
+        continuously without flashing a fallback.
+      </p>
+    </div>
+  )
+}

--- a/website/src/examples/data-fetching/index.tsx
+++ b/website/src/examples/data-fetching/index.tsx
@@ -1,0 +1,12 @@
+import ExampleSandpack from '@/components/ExampleSandpack'
+import {readExample} from '@/utils/readExample'
+
+export default function Example() {
+  return (
+    <ExampleSandpack
+      files={{
+        '/App.tsx': readExample('data-fetching', 'DataFetchingExample.tsx'),
+      }}
+    />
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `useObservablePromise` and `preloadObservablePromise` so RxJS data fetching can activate React Suspense / Activity pre-rendering via `use()`-compatible instrumented promises — without a provider.

`useObservable` cannot activate Suspense or participate in Activity pre-fetch (only a promise read with `use()` can). This hook returns a Promise subclass (with `status` / `value` / `reason`) that consumers pass to `React.use()`.

Rebased onto latest `current`. Docs cover all four hooks; the `useObservablePromise` demo lives at `/examples/data-fetching` since `/examples/suspense` is the hook-comparison demo from #459.

### API

```ts
const promise = useObservablePromise(observable$, { disabled?, ttl? })
const data = use(promise)

preloadObservablePromise(observable$, { ttl? }) // event-driven warm-up
```

### Behavior

- Suspends until the first emission (`firstValueFrom` semantics)
- First emission resolves the pending promise in place — the uSES snapshot is unchanged, so the unblock happens purely via promise resolution (no store-notification re-render, per async-react #3)
- Later emissions swap to a pre-fulfilled promise and update without re-suspending
- Expensive subtrees can opt into time-sliced updates with userland `useDeferredValue(promise)` + `memo`
- Errors go to the nearest Error Boundary (`catchError` documented for customization)
- Module-level WeakMap cache with configurable `ttl` retention; extending ttl after unmount re-arms both eviction and share grace (so long-lived sources stay connected for the new window)
- Mounted components pin their cache entry: `ttl` eviction only affects future consumers
- `disabled: true` fully prevents fetching (stronger than `useObservable`'s warm-up probe)
- `preloadObservablePromise` for hover/route-loader cache warm-up (starts immediately; hung sources stay pending until settle — prefer RxJS `timeout`)

### Docs & examples

- Guide: Data fetching with Suspense (incl. deferring expensive re-renders, observable-swap recipe, preload hang guidance)
- Reference: `useObservablePromise` + `preloadObservablePromise`
- Sandpack: `/examples/data-fetching` and `/examples/activity`

### Out of scope

- Actions (`useActionState` / `useOptimistic`) — follow-up
- RSC / hydration-perfect streaming SSR

## Demo

[use-observable-promise-examples-demo.mp4](https://cursor.com/agents/bc-3f624c65-b6b3-4225-ab59-bd6747315510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuse-observable-promise-examples-demo.mp4)

[Suspense example](https://cursor.com/agents/bc-3f624c65-b6b3-4225-ab59-bd6747315510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fsuspense-example.webp)
[Activity hover preload](https://cursor.com/agents/bc-3f624c65-b6b3-4225-ab59-bd6747315510/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Factivity-hover-preload.webp)

## Test plan

- [x] Core Suspense / identity / error / ttl / disabled / preload tests
- [x] First-emission bailout + Activity eviction-while-hidden regression
- [x] Concurrent tearing + `useDeferredValue` time-slicing interleaving test
- [x] StrictMode / SSR / type-level / WeakRef leak tests
- [x] ttl-extension after unmount keeps long-lived source connected (Bugbot)
- [x] Rebased onto latest `current`; lint/knip/tsc/build + 268 tests green
- [x] Review comments addressed (preload hang docs + share grace bounce)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f624c65-b6b3-4225-ab59-bd6747315510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f624c65-b6b3-4225-ab59-bd6747315510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

