### PR TITLE
chore: exit changesets pre-release mode for v5 stable

### DIFF
--- a/.changeset/clarify-disabled-option.md
+++ b/.changeset/clarify-disabled-option.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Clarify that `useObservable`'s `disabled` option pauses the live store subscription (and keeps returning the last value) but does not skip the render-phase warm-up subscription. Document swapping the observable when zero subscriptions are required.

--- a/.changeset/dedupe-hook-internals.md
+++ b/.changeset/dedupe-hook-internals.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Deduplicate the internals of `useObservable` and `useSyncObservable` into shared modules. The two hooks now share a single observable cache, so observing the same observable with both hooks reuses one shared source subscription and snapshot instead of two.

--- a/.changeset/deferred-use-observable.md
+++ b/.changeset/deferred-use-observable.md
@@ -2,8 +2,8 @@
 "react-rx": major
 ---
 
-**BREAKING:** `useObservable` now defers store updates with `useDeferredValue` — urgent renders keep the previous value while a background render catches up. Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash). SSR now renders exactly what the first client render would show (synchronous emissions win over the `initialValue`) and no longer throws when `initialValue` is omitted; synchronously erroring observables now fail the server render instead of masking the error until hydration.
+**BREAKING:** `useObservable` now defers store updates with `useDeferredValue` — urgent renders keep the previous value while a background render catches up. Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash). SSR renders synchronous emissions (instead of always using `initialValue`), no longer throws when `initialValue` is omitted, and fails the server render on synchronously erroring observables.
 
-New `useSyncObservable` preserves the exact v4 synchronous behavior, including the strict `getServerSnapshot` contract — switch to it for values feeding controlled inputs or strict server markup control (or rename wholesale for a mechanical migration).
+New `useSyncObservable` preserves v4's synchronous behavior and strict `getServerSnapshot` contract — use it for controlled inputs, or rename wholesale for a mechanical migration.
 
 See the [v4 to v5 migration guide](https://react-rx.dev/migrate/v4-to-v5).

--- a/.changeset/native-use-effect-event.md
+++ b/.changeset/native-use-effect-event.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Use React's native `useEffectEvent` instead of the `use-effect-event` polyfill.

--- a/.changeset/node-engines-22.md
+++ b/.changeset/node-engines-22.md
@@ -2,6 +2,4 @@
 "react-rx": major
 ---
 
-Require Node.js `>=22.12`, matching `sanity`'s `engines.node` field.
-
-Packages that declare an incompatible Node engine may see install warnings or failures under strict engine checks (`engine-strict` / `--engine-strict`).
+**BREAKING:** Require Node.js `>=22.12`, matching `sanity`'s `engines.node`.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "react-rx": "4.2.4",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,7 +6,6 @@
     "react-rx-website": "1.0.0"
   },
   "changesets": [
-    "dedupe-hook-internals",
     "deferred-use-observable",
     "node-engines-22",
     "react-peer-19-2",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,15 +6,11 @@
     "react-rx-website": "1.0.0"
   },
   "changesets": [
-    "clarify-disabled-option",
     "deferred-use-observable",
-    "native-use-effect-event",
     "node-engines-22",
-    "react-compiler-target-19",
     "react-peer-19-2",
     "remove-cjs",
     "rxjs-import-consolidate",
-    "use-observable-sync-termination-leak",
-    "vendor-observable-callback"
+    "use-observable-sync-termination-leak"
   ]
 }

--- a/.changeset/react-compiler-target-19.md
+++ b/.changeset/react-compiler-target-19.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Compile with React Compiler `target: '19'` and drop the `react-compiler-runtime` dependency. React 19 provides the runtime natively.

--- a/.changeset/remove-cjs.md
+++ b/.changeset/remove-cjs.md
@@ -2,6 +2,4 @@
 "react-rx": minor
 ---
 
-Stop publishing CommonJS builds. The package is now ESM-only.
-
-With the existing Node.js `>=22.12` engine requirement, `require()` of ESM is supported, so this is not a breaking change for consumers that follow `engines`.
+Stop publishing CommonJS builds — the package is ESM-only. With the Node.js `>=22.12` engine requirement, `require()` of ESM is supported, so this is not a breaking change for consumers that follow `engines`.

--- a/.changeset/rxjs-import-consolidate.md
+++ b/.changeset/rxjs-import-consolidate.md
@@ -2,4 +2,4 @@
 "react-rx": major
 ---
 
-**BREAKING:** Require RxJS `^7.2` as a peer dependency (operators are imported from `'rxjs'`, which landed in 7.2). Import operators from `'rxjs'` instead of the deprecated `'rxjs/operators'` path.
+**BREAKING:** Require RxJS `^7.2` as a peer dependency. Import operators from `'rxjs'` instead of the deprecated `'rxjs/operators'` path.

--- a/.changeset/use-observable-sync-termination-leak.md
+++ b/.changeset/use-observable-sync-termination-leak.md
@@ -2,4 +2,4 @@
 "react-rx": patch
 ---
 
-Fix a `useObservable` memory leak where observables that complete or error synchronously upon subscription (e.g. `of(...)`, a replayed-and-completed `shareReplay(1)`, a synchronous `throwError`) left an entry in the internal cache that its own teardown could no longer evict. A later committed mount of the same observable would clean the entry up as a side effect, but that never happens for server renders, `disabled` hooks, or renders that throw before commit — there the entry retained the last emitted snapshot (or error) for as long as the source observable itself stayed alive. In the synchronous error case the stale entry also replayed the old error on later mounts instead of re-subscribing the source, turning transient errors permanent.
+Fix a `useObservable` cache leak for observables that complete or error synchronously on subscribe. Stale entries could retain snapshots (or replay errors) indefinitely on server renders, `disabled` hooks, and renders that throw before commit.

--- a/.changeset/vendor-observable-callback.md
+++ b/.changeset/vendor-observable-callback.md
@@ -1,5 +1,0 @@
----
-"react-rx": patch
----
-
-Vendor `observableCallback` into the package and drop the `observable-callback` dependency.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Exits Changesets pre-release mode (`next` tag) and tidies the pending changesets so the consolidated `5.0.0` changelog reads cleanly.

### Pre exit
Updates `.changeset/pre.json` via `changeset pre exit` (`mode: "pre"` → `mode: "exit"`). After this merges, the Version Packages bot bumps `react-rx` from `5.0.0-next.7` to `5.0.0`, consumes the remaining changesets, and removes `pre.json`. Merging that Version Packages PR publishes `5.0.0` to npm `latest`.

### Changeset cleanup
**Deleted** (docs / internal-only — noise in a stable major changelog):
- `clarify-disabled-option` — docs clarification only
- `native-use-effect-event` — dropped `use-effect-event` polyfill
- `react-compiler-target-19` — compiler `target: '19'` / runtime drop
- `vendor-observable-callback` — inlined a dependency
- `dedupe-hook-internals` — shared cache between hooks is an implementation detail for v4→v5 (v4 had no `useSyncObservable`)

**Tightened** (kept for the stable notes):
- Deferred `useObservable` / `useSyncObservable` (major)
- Node `>=22.12`, React `^19.2`, RxJS `^7.2` peer/engine bumps (major)
- ESM-only / drop CJS (minor)
- Sync-termination cache leak fix (patch)

Mirrors how pre mode was entered in #433.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ad386952-1f7d-4c11-9ce3-b401b1877013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad386952-1f7d-4c11-9ce3-b401b1877013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

