### PR TITLE
refactor: dedupe useObservable/useSyncObservable internals into shared modules

### DIFF
--- a/.changeset/dedupe-hook-internals.md
+++ b/.changeset/dedupe-hook-internals.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Deduplicate the internals of `useObservable` and `useSyncObservable` into shared modules. The two hooks now share a single observable cache, so observing the same observable with both hooks reuses one shared source subscription and snapshot instead of two.

--- a/packages/react-rx/src/__tests__/sharedCache.test.tsx
+++ b/packages/react-rx/src/__tests__/sharedCache.test.tsx
@@ -1,0 +1,28 @@
+import {renderHook} from '@testing-library/react'
+import {Observable} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+test('useObservable and useSyncObservable share one source subscription for the same observable', async () => {
+  let subscribeCount = 0
+  const observable = new Observable<number>((subscriber) => {
+    subscriber.next(subscribeCount++)
+  })
+
+  const deferred = renderHook(() => useObservable(observable))
+  expect(deferred.result.current).toBe(0)
+
+  const sync = renderHook(() => useSyncObservable(observable))
+  expect(sync.result.current).toBe(0)
+  expect(subscribeCount).toBe(1)
+
+  deferred.unmount()
+  sync.unmount()
+  await Promise.resolve()
+
+  const remount = renderHook(() => useObservable(observable))
+  expect(remount.result.current).toBe(1)
+  remount.unmount()
+})

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -15,8 +15,8 @@ import {
 } from 'rxjs'
 import {expect, test} from 'vitest'
 
+import type {UseObservableOptions} from '../types'
 import {useObservable} from '../useObservable'
-import type {UseObservableOptions} from '../useSyncObservable'
 
 test('should subscribe immediately on component mount and unsubscribe on component unmount', async () => {
   let subscribed = false

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -14,7 +14,8 @@ import {
 } from 'rxjs'
 import {expect, test} from 'vitest'
 
-import {useSyncObservable, type UseObservableOptions} from '../useSyncObservable'
+import type {UseObservableOptions} from '../types'
+import {useSyncObservable} from '../useSyncObservable'
 
 test('should subscribe immediately on component mount and unsubscribe on component unmount', async () => {
   let subscribed = false

--- a/packages/react-rx/src/cache.ts
+++ b/packages/react-rx/src/cache.ts
@@ -1,0 +1,99 @@
+import {
+  asapScheduler,
+  catchError,
+  finalize,
+  map,
+  type Observable,
+  type ObservedValueOf,
+  of,
+  share,
+  tap,
+  timer,
+} from 'rxjs'
+
+import {getValue} from './utils'
+
+interface ObservableState<T> {
+  didEmit: boolean
+  snapshot?: T
+  error?: unknown
+}
+
+interface CacheRecord<T> {
+  observable: Observable<void>
+  state: ObservableState<T>
+  getSnapshot: (initialValue: unknown) => T
+}
+
+const cache = new WeakMap<Observable<any>, CacheRecord<any>>()
+
+/**
+ * Returns the external-store adapter for `observable` — a notifier observable plus a `getSnapshot`
+ * suitable for `useSyncExternalStore` — creating (and warming up) a shared cache entry if there
+ * isn't one yet. The cache is shared between `useObservable` and `useSyncObservable`, so both
+ * hooks reuse the same entry and source subscription for the same observable.
+ *
+ * @internal
+ */
+export function getOrCreateStore<ObservableType extends Observable<any>>(
+  observable: ObservableType,
+): CacheRecord<ObservedValueOf<ObservableType>> {
+  const cached = cache.get(observable)
+  if (cached) {
+    return cached
+  }
+  // This separate object is used as a stable reference to the cache entry's snapshot and error.
+  // It's used by the `getSnapshot` closure.
+  const state: ObservableState<ObservedValueOf<ObservableType>> = {
+    didEmit: false,
+  }
+  const entry: CacheRecord<ObservedValueOf<ObservableType>> = {
+    state,
+    observable: observable.pipe(
+      map((value) => ({snapshot: value, error: undefined})),
+      catchError((error) => of({snapshot: undefined, error})),
+      tap(({snapshot, error}) => {
+        state.didEmit = true
+        state.snapshot = snapshot
+        state.error = error
+      }),
+      // Note: any value or error emitted by the provided observable will be mapped to the cache entry's mutable state
+      // and the observable is thereafter only used as a notifier to call `onStoreChange`, hence the `void` return type.
+      map((value) => void value),
+      // Ensure that the cache entry is deleted when the observable completes or errors.
+      // Comparing `state` (unique per entry) prevents teardown of a stale, already replaced entry
+      // from deleting its successor.
+      finalize(() => {
+        if (cache.get(observable)?.state === state) {
+          cache.delete(observable)
+        }
+      }),
+      share({resetOnRefCountZero: () => timer(0, asapScheduler)}),
+    ),
+    getSnapshot: (initialValue) => {
+      if (state.error) {
+        throw state.error
+      }
+      return (
+        state.didEmit ? state.snapshot : getValue(initialValue)
+      ) as ObservedValueOf<ObservableType>
+    },
+  }
+
+  // The entry must be added to the cache before the eager subscription below: if the observable
+  // terminates synchronously during it, `finalize` runs right away and must find the entry in order to
+  // delete it. Inserting the entry afterwards would retain it (and its last snapshot or error) for as
+  // long as the source observable lives, and poisoned entries would replay stale errors on remount
+  // instead of re-subscribing the source.
+  cache.set(observable, entry)
+
+  // Eagerly subscribe during render to warm up a synchronous snapshot into `state`. This runs even
+  // when `disabled` is true — `disabled` only pauses the hooks' live store subscription. The
+  // subscribe/unsubscribe here does not keep the observable alive; the store subscription does.
+  const subscription = entry.observable.subscribe()
+  subscription.unsubscribe()
+
+  // For synchronously terminating observables the entry has already been evicted from the cache again
+  // at this point, so return the local reference instead of reading back from the cache.
+  return entry
+}

--- a/packages/react-rx/src/cache.ts
+++ b/packages/react-rx/src/cache.ts
@@ -1,15 +1,5 @@
-import {
-  asapScheduler,
-  catchError,
-  finalize,
-  map,
-  type Observable,
-  type ObservedValueOf,
-  of,
-  share,
-  tap,
-  timer,
-} from 'rxjs'
+import {asapScheduler, catchError, finalize, map, of, share, tap, timer} from 'rxjs'
+import type {Observable, ObservedValueOf} from 'rxjs'
 
 import {getValue} from './utils'
 

--- a/packages/react-rx/src/index.ts
+++ b/packages/react-rx/src/index.ts
@@ -1,5 +1,6 @@
 'use client'
 
+export * from './types'
 export * from './useObservable'
 export * from './useObservableEvent'
 export * from './useSyncObservable'

--- a/packages/react-rx/src/types.ts
+++ b/packages/react-rx/src/types.ts
@@ -1,0 +1,9 @@
+/** @public */
+export interface UseObservableOptions {
+  /**
+   * Pause the active store subscription. While `true`, later emissions do not update the component
+   * and the last received value (or `initialValue`) is returned. Does not skip the render-phase
+   * warm-up subscription — swap the observable if you need zero subscriptions.
+   */
+  disabled?: boolean
+}

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -1,47 +1,9 @@
-// NOTE: This file intentionally duplicates `useSyncObservable.ts` — the only shared code is the
-// type-only `UseObservableOptions` import. Keep the copies in sync instead of extracting shared
-// helpers or merging the two WeakMap caches; deduplication is a planned follow-up PR.
 import {useCallback, useDeferredValue, useMemo, useSyncExternalStore} from 'react'
-import {
-  asapScheduler,
-  catchError,
-  finalize,
-  map,
-  type Observable,
-  type ObservedValueOf,
-  of,
-  share,
-  tap,
-  timer,
-} from 'rxjs'
+import {type Observable, type ObservedValueOf} from 'rxjs'
 
-import type {UseObservableOptions} from './useSyncObservable'
-
-function getValue<T>(value: T): T extends () => infer U ? U : T {
-  return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U
-    ? U
-    : T
-}
-
-interface ObservableState<T> {
-  didEmit: boolean
-  snapshot?: T
-  error?: unknown
-}
-
-interface CacheRecord<T> {
-  observable: Observable<void>
-  state: {
-    didEmit: boolean
-    snapshot?: T
-    error?: unknown
-  }
-  getSnapshot: (initialValue: unknown) => T
-}
-
-const cache = new WeakMap<Observable<any>, CacheRecord<any>>()
-
-const EMPTY_OBJECT = {}
+import {getOrCreateStore} from './cache'
+import type {UseObservableOptions} from './types'
+import {EMPTY_OBJECT} from './utils'
 
 /**
  * Subscribe to an observable and return its latest value, with store updates deferred via
@@ -82,66 +44,7 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
 ): InitialValue | ObservedValueOf<ObservableType> {
   const {disabled = false} = options
 
-  const instance = useMemo(() => {
-    const cached = cache.get(observable)
-    if (cached) {
-      return cached
-    }
-    // This separate object is used as a stable reference to the cache entry's snapshot and error.
-    // It's used by the `getSnapshot` closure.
-    const state: ObservableState<ObservedValueOf<ObservableType>> = {
-      didEmit: false,
-    }
-    const entry: CacheRecord<ObservedValueOf<ObservableType>> = {
-      state,
-      observable: observable.pipe(
-        map((value) => ({snapshot: value, error: undefined})),
-        catchError((error) => of({snapshot: undefined, error})),
-        tap(({snapshot, error}) => {
-          state.didEmit = true
-          state.snapshot = snapshot
-          state.error = error
-        }),
-        // Note: any value or error emitted by the provided observable will be mapped to the cache entry's mutable state
-        // and the observable is thereafter only used as a notifier to call `onStoreChange`, hence the `void` return type.
-        map((value) => void value),
-        // Ensure that the cache entry is deleted when the observable completes or errors.
-        // Comparing `state` (unique per entry) prevents teardown of a stale, already replaced entry
-        // from deleting its successor.
-        finalize(() => {
-          if (cache.get(observable)?.state === state) {
-            cache.delete(observable)
-          }
-        }),
-        share({resetOnRefCountZero: () => timer(0, asapScheduler)}),
-      ),
-      getSnapshot: (initialValue) => {
-        if (state.error) {
-          throw state.error
-        }
-        return (
-          state.didEmit ? state.snapshot : getValue(initialValue)
-        ) as ObservedValueOf<ObservableType>
-      },
-    }
-
-    // The entry must be added to the cache before the eager subscription below: if the observable
-    // terminates synchronously during it, `finalize` runs right away and must find the entry in order to
-    // delete it. Inserting the entry afterwards would retain it (and its last snapshot or error) for as
-    // long as the source observable lives, and poisoned entries would replay stale errors on remount
-    // instead of re-subscribing the source.
-    cache.set(observable, entry)
-
-    // Eagerly subscribe during render to warm up a synchronous snapshot into `state`. This runs even
-    // when `disabled` is true — `disabled` only pauses the live store subscription below. The
-    // subscribe/unsubscribe here does not keep the observable alive; the store subscription does.
-    const subscription = entry.observable.subscribe()
-    subscription.unsubscribe()
-
-    // For synchronously terminating observables the entry has already been evicted from the cache again
-    // at this point, so return the local reference instead of reading back from the cache.
-    return entry
-  }, [observable])
+  const instance = useMemo(() => getOrCreateStore(observable), [observable])
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -1,5 +1,5 @@
 import {useCallback, useDeferredValue, useMemo, useSyncExternalStore} from 'react'
-import {type Observable, type ObservedValueOf} from 'rxjs'
+import type {Observable, ObservedValueOf} from 'rxjs'
 
 import {getOrCreateStore} from './cache'
 import type {UseObservableOptions} from './types'

--- a/packages/react-rx/src/useSyncObservable.ts
+++ b/packages/react-rx/src/useSyncObservable.ts
@@ -1,5 +1,5 @@
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
-import {type Observable, type ObservedValueOf} from 'rxjs'
+import type {Observable, ObservedValueOf} from 'rxjs'
 
 import {getOrCreateStore} from './cache'
 import type {UseObservableOptions} from './types'

--- a/packages/react-rx/src/useSyncObservable.ts
+++ b/packages/react-rx/src/useSyncObservable.ts
@@ -1,55 +1,9 @@
-// NOTE: `useObservable.ts` intentionally duplicates this file (plus a useDeferredValue wrap and a
-// snapshot-based getServerSnapshot). Keep the copies in sync instead of extracting shared helpers
-// or merging the two WeakMap caches; deduplication is a planned follow-up PR.
 import {useCallback, useMemo, useSyncExternalStore} from 'react'
-import {
-  asapScheduler,
-  catchError,
-  finalize,
-  map,
-  type Observable,
-  type ObservedValueOf,
-  of,
-  share,
-  tap,
-  timer,
-} from 'rxjs'
+import {type Observable, type ObservedValueOf} from 'rxjs'
 
-function getValue<T>(value: T): T extends () => infer U ? U : T {
-  return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U
-    ? U
-    : T
-}
-
-interface ObservableState<T> {
-  didEmit: boolean
-  snapshot?: T
-  error?: unknown
-}
-
-interface CacheRecord<T> {
-  observable: Observable<void>
-  state: {
-    didEmit: boolean
-    snapshot?: T
-    error?: unknown
-  }
-  getSnapshot: (initialValue: unknown) => T
-}
-
-const cache = new WeakMap<Observable<any>, CacheRecord<any>>()
-
-const EMPTY_OBJECT = {}
-
-/** @public */
-export interface UseObservableOptions {
-  /**
-   * Pause the active store subscription. While `true`, later emissions do not update the component
-   * and the last received value (or `initialValue`) is returned. Does not skip the render-phase
-   * warm-up subscription — swap the observable if you need zero subscriptions.
-   */
-  disabled?: boolean
-}
+import {getOrCreateStore} from './cache'
+import type {UseObservableOptions} from './types'
+import {EMPTY_OBJECT, getValue} from './utils'
 
 /**
  * Subscribe to an observable and return its latest value synchronously via
@@ -89,66 +43,7 @@ export function useSyncObservable<ObservableType extends Observable<any>, Initia
 ): InitialValue | ObservedValueOf<ObservableType> {
   const {disabled = false} = options
 
-  const instance = useMemo(() => {
-    const cached = cache.get(observable)
-    if (cached) {
-      return cached
-    }
-    // This separate object is used as a stable reference to the cache entry's snapshot and error.
-    // It's used by the `getSnapshot` closure.
-    const state: ObservableState<ObservedValueOf<ObservableType>> = {
-      didEmit: false,
-    }
-    const entry: CacheRecord<ObservedValueOf<ObservableType>> = {
-      state,
-      observable: observable.pipe(
-        map((value) => ({snapshot: value, error: undefined})),
-        catchError((error) => of({snapshot: undefined, error})),
-        tap(({snapshot, error}) => {
-          state.didEmit = true
-          state.snapshot = snapshot
-          state.error = error
-        }),
-        // Note: any value or error emitted by the provided observable will be mapped to the cache entry's mutable state
-        // and the observable is thereafter only used as a notifier to call `onStoreChange`, hence the `void` return type.
-        map((value) => void value),
-        // Ensure that the cache entry is deleted when the observable completes or errors.
-        // Comparing `state` (unique per entry) prevents teardown of a stale, already replaced entry
-        // from deleting its successor.
-        finalize(() => {
-          if (cache.get(observable)?.state === state) {
-            cache.delete(observable)
-          }
-        }),
-        share({resetOnRefCountZero: () => timer(0, asapScheduler)}),
-      ),
-      getSnapshot: (initialValue) => {
-        if (state.error) {
-          throw state.error
-        }
-        return (
-          state.didEmit ? state.snapshot : getValue(initialValue)
-        ) as ObservedValueOf<ObservableType>
-      },
-    }
-
-    // The entry must be added to the cache before the eager subscription below: if the observable
-    // terminates synchronously during it, `finalize` runs right away and must find the entry in order to
-    // delete it. Inserting the entry afterwards would retain it (and its last snapshot or error) for as
-    // long as the source observable lives, and poisoned entries would replay stale errors on remount
-    // instead of re-subscribing the source.
-    cache.set(observable, entry)
-
-    // Eagerly subscribe during render to warm up a synchronous snapshot into `state`. This runs even
-    // when `disabled` is true — `disabled` only pauses the live store subscription below. The
-    // subscribe/unsubscribe here does not keep the observable alive; the store subscription does.
-    const subscription = entry.observable.subscribe()
-    subscription.unsubscribe()
-
-    // For synchronously terminating observables the entry has already been evicted from the cache again
-    // at this point, so return the local reference instead of reading back from the cache.
-    return entry
-  }, [observable])
+  const instance = useMemo(() => getOrCreateStore(observable), [observable])
 
   const subscribe = useCallback(
     (onStoreChange: () => void) => {
@@ -169,6 +64,8 @@ export function useSyncObservable<ObservableType extends Observable<any>, Initia
     () => {
       return instance.getSnapshot(initialValue)
     },
+    // Strict v4 server contract: the server renders the resolved `initialValue`, and throws
+    // (missing getServerSnapshot) without one — even when the observable emits synchronously.
     typeof initialValue === 'undefined'
       ? undefined
       : () => getValue(initialValue) as ObservedValueOf<ObservableType>,

--- a/packages/react-rx/src/utils.ts
+++ b/packages/react-rx/src/utils.ts
@@ -1,0 +1,7 @@
+export const EMPTY_OBJECT = {}
+
+export function getValue<T>(value: T): T extends () => infer U ? U : T {
+  return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U
+    ? U
+    : T
+}

--- a/packages/react-rx/src/utils.ts
+++ b/packages/react-rx/src/utils.ts
@@ -1,4 +1,4 @@
-export const EMPTY_OBJECT = {}
+export const EMPTY_OBJECT: Readonly<Record<string, never>> = Object.freeze({})
 
 export function getValue<T>(value: T): T extends () => infer U ? U : T {
   return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #459: removes the intentional duplication between `useObservable.ts` and `useSyncObservable.ts`.

## What changed

- `src/types.ts` — holds the public `UseObservableOptions` interface (re-exported from `src/index.ts` so the public API is unchanged).
- `src/utils.ts` — exports frozen `EMPTY_OBJECT` and `getValue`.
- `src/cache.ts` — holds `ObservableState`, `CacheRecord`, the `WeakMap` cache, and `getOrCreateStore(observable)`, which returns the cached external-store adapter (notifier observable + `getSnapshot`) for an observable, creating and warming it up if missing. Named `getOrCreateStore` instead of `getOrWarmup` since the record is exactly what `useSyncExternalStore` consumes and the warm-up is an implementation detail — trivial to rename if preferred.
- Both hooks now reduce to `getOrCreateStore` + `subscribe` callback + `useSyncExternalStore`; `useObservable` adds the always-provided `getServerSnapshot` and the trailing `useDeferredValue`, while `useSyncObservable` keeps its strict v4 server contract (`getServerSnapshot` only when `initialValue` is defined).
- The two per-hook `WeakMap` caches are merged into one, so observing the same observable with both hooks now shares a single source subscription and snapshot (covered by a changeset + `sharedCache.test.tsx`).
- Test imports of `UseObservableOptions` updated to point at `../types`.

## Review follow-ups

- Prefer `import type {…}` for type-only rxjs imports.
- Freeze `EMPTY_OBJECT` as `Readonly<Record<string, never>>`.
- Add a regression test that mounts both hooks against the same observable and asserts a single source subscription.

## Verification

- `pnpm lint` — clean
- `pnpm test` — 168 tests passed across 18 files (normal + react-compiler projects, with typecheck)
- `tsc -p packages/react-rx/tsconfig.json` — clean
- `oxfmt --check` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4da5270-5c51-41bc-9523-9d7779ed467a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4da5270-5c51-41bc-9523-9d7779ed467a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

