### PR TITLE
fix: restore use-effect-event for memo and forwardRef

### DIFF
--- a/.changeset/safe-effect-events.md
+++ b/.changeset/safe-effect-events.md
@@ -1,0 +1,5 @@
+---
+"react-rx": patch
+---
+
+Restore the `use-effect-event` ponyfill so effect events see the latest values in `memo` and `forwardRef` components.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,11 @@
       "semanticCommitType": "chore"
     },
     {
+      "matchPackageNames": ["use-effect-event"],
+      "rangeStrategy": "bump",
+      "semanticCommitType": "fix"
+    },
+    {
       "matchPackageNames": ["oxlint", "oxlint-tsgolint"],
       "groupName": "oxlint",
       "semanticCommitType": "chore"

--- a/packages/react-rx/package.json
+++ b/packages/react-rx/package.json
@@ -67,6 +67,9 @@
     "test": "vitest run --typecheck",
     "watch": "tsdown --watch"
   },
+  "dependencies": {
+    "use-effect-event": "^2.0.3"
+  },
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@rolldown/plugin-babel": "^0.2.3",

--- a/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
+++ b/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
@@ -1,0 +1,60 @@
+import {render} from '@testing-library/react'
+import {forwardRef, memo, useEffect, useEffectEvent as useNativeEffectEvent} from 'react'
+import {describe, expect, test} from 'vitest'
+
+import {useEffectEvent} from '../useEffectEvent'
+
+const componentTypes = ['memo', 'forwardRef'] as const
+
+type ComponentType = (typeof componentTypes)[number]
+type EffectEventHook = (callback: () => void) => () => void
+
+function expectLatestValue(useEvent: EffectEventHook, componentType: ComponentType) {
+  const seen: number[] = []
+
+  function useRecord(value: number) {
+    const onEvent = useEvent(() => {
+      seen.push(value)
+    })
+
+    useEffect(() => {
+      onEvent()
+    }, [onEvent, value])
+  }
+
+  if (componentType === 'memo') {
+    const Component = memo(function Component({value}: {value: number}) {
+      useRecord(value)
+      return null
+    })
+    const {rerender} = render(<Component value={0} />)
+    rerender(<Component value={1} />)
+  } else {
+    const Component = forwardRef<unknown, {value: number}>(function Component({value}, _ref) {
+      useRecord(value)
+      return null
+    })
+    const {rerender} = render(<Component value={0} />)
+    rerender(<Component value={1} />)
+  }
+
+  expect(seen).toEqual([0, 1])
+}
+
+describe('useEffectEvent', () => {
+  for (const componentType of componentTypes) {
+    test(`sees the latest value in ${componentType} components`, () => {
+      expectLatestValue(useEffectEvent, componentType)
+    })
+  }
+})
+
+describe('React.useEffectEvent', () => {
+  // These expected failures become unexpected passes when the lowest supported
+  // React version is safe, prompting us to replace the ponyfill with the native hook.
+  for (const componentType of componentTypes) {
+    test.fails(`sees the latest value in ${componentType} components`, () => {
+      expectLatestValue(useNativeEffectEvent, componentType)
+    })
+  }
+})

--- a/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
+++ b/packages/react-rx/src/__tests__/useEffectEvent.test.tsx
@@ -50,8 +50,9 @@ describe('useEffectEvent', () => {
 })
 
 describe('React.useEffectEvent', () => {
-  // These expected failures become unexpected passes when the lowest supported
-  // React version is safe, prompting us to replace the ponyfill with the native hook.
+  // These expected failures become unexpected passes when the tested React
+  // version contains the upstream fix. Before replacing the ponyfill, ensure
+  // the fix is also available in the lowest supported React version.
   for (const componentType of componentTypes) {
     test.fails(`sees the latest value in ${componentType} components`, () => {
       expectLatestValue(useNativeEffectEvent, componentType)

--- a/packages/react-rx/src/useEffectEvent.ts
+++ b/packages/react-rx/src/useEffectEvent.ts
@@ -1,0 +1,5 @@
+// TODO: switch to `useEffectEvent` from `react` once
+// https://github.com/facebook/react/issues/34818 is fixed in the lowest React
+// version we support. React 19.2 keeps first-render values when the calling
+// component is wrapped in `forwardRef` or `memo`.
+export {useEffectEvent} from 'use-effect-event'

--- a/packages/react-rx/src/useObservableEvent.ts
+++ b/packages/react-rx/src/useObservableEvent.ts
@@ -1,7 +1,8 @@
-import {useEffect, useEffectEvent, useState} from 'react'
+import {useEffect, useState} from 'react'
 import {type Observable} from 'rxjs'
 
 import {observableCallback} from './observableCallback'
+import {useEffectEvent} from './useEffectEvent'
 
 /** @public */
 export function useObservableEvent<T, U>(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,10 @@ importers:
         version: 7.0.2
 
   packages/react-rx:
+    dependencies:
+      use-effect-event:
+        specifier: ^2.0.3
+        version: 2.0.3(react@19.2.8)
     devDependencies:
       '@babel/core':
         specifier: ^7.29.7
@@ -4233,6 +4237,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-effect-event@2.0.3:
+    resolution: {integrity: sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==}
+    peerDependencies:
+      react: ^18.3 || ^19.0.0-0
 
   use-error-boundary@2.0.6:
     resolution: {integrity: sha512-AWCVKSAanLe6R/on/ZkHYtGKfXs8BQX6z/TUGYqtvkajLqQyrGKJJscbahtq8OyN8L3LqTRjJWx4gCOLmfIObw==}
@@ -8853,6 +8862,10 @@ snapshots:
       browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-effect-event@2.0.3(react@19.2.8):
+    dependencies:
+      react: 19.2.8
 
   use-error-boundary@2.0.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/website/src/components/Sandpack.tsx
+++ b/website/src/components/Sandpack.tsx
@@ -75,7 +75,9 @@ export default function SandpackComponent({
            * In production we should always use the package on npm, which supports canaries
            * while locally we use the build package
            */
-          ...(reactRxSource ? {} : {'react-rx': reactRxPackageJson.version}),
+          ...(reactRxSource
+            ? reactRxPackageJson.dependencies
+            : {'react-rx': reactRxPackageJson.version}),
           'rxjs': reactRxPackageJson.peerDependencies.rxjs,
           'react': reactRxPackageJson.devDependencies.react,
           'react-dom': reactRxPackageJson.devDependencies['react-dom'],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- restore the `use-effect-event` ponyfill for `useObservableEvent`
- cover fresh callback values in `memo` and `forwardRef` components
- keep expected-failure checks for React's native hook so a future safe React version is visible in CI
- provide `react-rx` runtime dependencies when Sandpack injects the local build
- add a patch changeset and restore Renovate handling for the dependency

## Testing
- `pnpm --filter react-rx exec vitest run src/__tests__/useEffectEvent.test.tsx --typecheck` (4 passed, 4 expected failures across default and React Compiler projects)
- `pnpm test` (172 passed, 4 expected failures)
- `pnpm lint`
- `pnpm --filter react-rx-website build`
- GitHub CI: build, lint, knip, and test matrix pass on Linux, macOS, Windows, Node LTS, and latest
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13a07be9-9b92-44e1-9c20-ceec108f57d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13a07be9-9b92-44e1-9c20-ceec108f57d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

