### PR TITLE
fix: publish v4 releases with `version-4` dist-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "pnpm --filter react-rx-website dev",
     "format": "oxfmt && pnpm lint --fix",
     "lint": "oxlint",
-    "release": "changeset publish",
+    "release": "changeset publish --tag version-4",
     "test": "pnpm --filter react-rx test",
     "watch": "pnpm --filter react-rx watch"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #457

Now that `react-rx@5` is on the `latest` npm dist-tag (`5.0.1`), releases from the `v4` branch must not overwrite it.

Updates the root `release` script to `changeset publish --tag version-4`, matching the pattern used in next-sanity (`--tag version-12`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-daaea8cc-8c5a-48b2-b2ec-9dbc0b89a599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-daaea8cc-8c5a-48b2-b2ec-9dbc0b89a599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

