### PR TITLE
fix: make useObservable deferral identity-coherent

### DIFF
--- a/.changeset/deferred-identity-coherent.md
+++ b/.changeset/deferred-identity-coherent.md
@@ -1,0 +1,5 @@
+---
+'react-rx': patch
+---
+
+fix: make `useObservable` deferral identity-coherent. The observable identity and its value are now deferred as one snapshot, and when the observable identity changes (e.g. it is memoized on a document id that just changed) the hook falls back to the live value — so the previous identity's value never renders under the new one.

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -3,6 +3,7 @@ import {startTransition, useMemo} from 'react'
 import {renderToString} from 'react-dom/server'
 import {
   asyncScheduler,
+  BehaviorSubject,
   map,
   Observable,
   of,
@@ -249,6 +250,59 @@ test('should re-subscribe when receiving a new observable', () => {
   unmount()
 })
 
+test('falls back to the live value when the observable identity changes (deferral is identity-coherent)', () => {
+  const subjectA = new BehaviorSubject('value for a')
+  const subjectB = new BehaviorSubject('initial for b')
+  const renderTimeline: string[] = []
+
+  function ObservableComponent({observable}: {observable: BehaviorSubject<string>}) {
+    renderTimeline.push(useObservable(observable, 'fallback'))
+    return null
+  }
+  const {rerender, unmount} = render(<ObservableComponent observable={subjectA} />)
+  expect(renderTimeline.at(-1)).toBe('value for a')
+
+  const timelineLengthBeforeSwitch = renderTimeline.length
+  rerender(<ObservableComponent observable={subjectB} />)
+
+  // The render right after the identity change must reflect the new observable
+  // (BehaviorSubject emits synchronously), never the deferred snapshot belonging
+  // to the previous observable.
+  expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
+  expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+
+  act(() => subjectB.next('updated for b'))
+  expect(renderTimeline.at(-1)).toBe('updated for b')
+
+  unmount()
+})
+
+test('identity change to an async observable renders the initialValue immediately, never the previous value', () => {
+  const subjectA = new BehaviorSubject('value for a')
+  const subjectB = new Subject<string>()
+  const renderTimeline: string[] = []
+
+  function ObservableComponent({observable}: {observable: Observable<string>}) {
+    renderTimeline.push(useObservable(observable, 'initial'))
+    return null
+  }
+  const {rerender, unmount} = render(<ObservableComponent observable={subjectA} />)
+  expect(renderTimeline.at(-1)).toBe('value for a')
+
+  const timelineLengthBeforeSwitch = renderTimeline.length
+  rerender(<ObservableComponent observable={subjectB} />)
+
+  // The new observable has not emitted yet, so the urgent render right after the
+  // switch shows the initialValue — not the previous observable's deferred value.
+  expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial')
+  expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+
+  act(() => subjectB.next('value for b'))
+  expect(renderTimeline.at(-1)).toBe('value for b')
+
+  unmount()
+})
+
 test('should return undefined if observable emits undefined, also when given initial value', () => {
   const values$ = new Subject<string | undefined>()
   const {result, unmount} = renderHook(() => useObservable(values$, 'initial'))
@@ -374,9 +428,9 @@ test('should return the actual value when the hook is disabled and then re-enabl
 })
 
 test('sync emission wins over initialValue on the first render (no flash)', () => {
-  // useDeferredValue's second arg is instance.getSnapshot(initialValue), which equals the
-  // sync emission after warm-up. mountDeferredValueImpl therefore memoizes 'sync' and may
-  // schedule a bail-out deferred pass that also returns 'sync' — never 'initial'.
+  // useDeferredValue's second arg is the live snapshot, which holds the sync emission
+  // after warm-up. mountDeferredValueImpl therefore memoizes 'sync' and may schedule a
+  // bail-out deferred pass that also returns 'sync' — never 'initial'.
   const returnedValues: unknown[] = []
   function ObservableComponent() {
     returnedValues.push(useObservable(of('sync'), 'initial'))
@@ -471,7 +525,8 @@ test('initialValue factories must be pure', () => {
   }
 
   const {result} = renderHook(() => useObservable(values$, factory))
-  // Pre-emission: uSES getSnapshot + useDeferredValue second arg each call the factory per render.
+  // Pre-emission: uSES calls getSnapshot (factory included) during render and again
+  // when checking for tearing on commit.
   expect(factoryCalls).toBeGreaterThanOrEqual(2)
   expect(result.current).toBe('initial')
   const callsBeforeEmit = factoryCalls

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -494,7 +494,7 @@ test('same-ttl preload after unmount renews share grace for long-lived sources',
   })
 
   function Parent() {
-    const p = useObservablePromise(observable, {ttl: 40})
+    const p = useObservablePromise(observable, {ttl: 200})
     return (
       <Suspense fallback={<Fallback />}>
         <Reader promise={p} />
@@ -509,12 +509,12 @@ test('same-ttl preload after unmount renews share grace for long-lived sources',
   await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('one'))
   unmount()
 
-  // Still inside the original 40ms grace: renew with the same ttl. Without a
-  // share bounce the disconnect still fires at unmount+40ms while eviction is
-  // pushed to touch+40ms — emissions in that gap are lost.
-  await wait(20)
-  void preloadObservablePromise(observable, {ttl: 40})
-  await wait(30) // ~50ms after unmount, ~30ms after renew — only valid if bounced
+  // Still inside the original 200ms grace: renew with the same ttl. Without a
+  // share bounce the disconnect still fires at unmount+200ms while eviction is
+  // pushed to touch+200ms — emissions in that gap are lost.
+  await wait(100)
+  void preloadObservablePromise(observable, {ttl: 200})
+  await wait(150) // ~250ms after unmount, ~150ms after renew — only valid if bounced
   expect(active).toBe(1)
 
   await act(async () => {

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -14,6 +14,12 @@ import {EMPTY_OBJECT} from './utils'
  * Suspense fallback. Mounts, remounts, and `<Activity>` reveals still render the current snapshot
  * synchronously (no initial-value flash).
  *
+ * The deferral is identity-coherent: unlike a bare `useDeferredValue(useObservable(...))`, the
+ * observable identity and its value are deferred as one snapshot, and when the observable identity
+ * changes (e.g. it is memoized on a document id that just changed) the hook falls back to the live
+ * value — typically the new observable's synchronous emission or the `initialValue` — so the
+ * previous identity's value never renders under the new one.
+ *
  * On the server this hook renders exactly what the client's first paint will show (a synchronous
  * emission when there is one, else the resolved `initialValue`, else nothing) and never throws
  * for a missing `initialValue`. Prefer {@link useSyncObservable} for controlled inputs or when you
@@ -71,11 +77,20 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
     () => instance.getSnapshot(initialValue),
   )
 
+  // Defer identity and value as one snapshot so they can never tear — the
+  // deferred value always belongs to the deferred observable.
+  const snapshot = useMemo(() => ({observable, value}), [observable, value])
+
   // Second arg is only read on mount / Activity reveal (mount path). Passing the
   // live snapshot means those renders show the current value with no flash;
   // later store updates are deferred. On the server, Fizz returns this arg and
-  // getServerSnapshot returns the same snapshot, so SSR matches the first client paint.
-  // Safe if getSnapshot throws: the useSyncExternalStore call above throws first.
-  // React Compiler may memoize this getSnapshot call — harmless, React only reads it on mount/reveal.
-  return useDeferredValue(value, instance.getSnapshot(initialValue))
+  // it holds the same value getServerSnapshot returned, so SSR matches the
+  // first client paint.
+  const deferredSnapshot = useDeferredValue(snapshot, snapshot)
+
+  // When the observable identity just changed, the deferred snapshot still
+  // belongs to the previous observable. Fall back to the live value (typically
+  // the new observable's sync emission or the initialValue) so the previous
+  // identity's value never renders under the new one.
+  return deferredSnapshot.observable === observable ? deferredSnapshot.value : value
 }

--- a/website/src/content/migrate/v4-to-v5.mdx
+++ b/website/src/content/migrate/v4-to-v5.mdx
@@ -19,7 +19,7 @@ In v4, `useObservable` was built on [`useSyncExternalStore`](https://react.dev/r
 
 v5 makes that the library default:
 
-- **`useObservable`** — store updates are deferred with `useDeferredValue`. Urgent renders keep the previous value; a background render catches up. Mounts, remounts, and `<Activity>` reveals still show the live snapshot (no initial-value flash).
+- **`useObservable`** — store updates are deferred with `useDeferredValue`. Urgent renders keep the previous value; a background render catches up. Mounts, remounts, and `<Activity>` reveals still show the live snapshot (no initial-value flash). The deferral is identity-coherent: when the observable identity changes, the hook falls back to the live value so the previous observable's value never renders under the new one — a stale-value bug a hand-rolled `useDeferredValue(useObservable(...))` wrapper is prone to.
 - **`useSyncObservable`** — exact v4 synchronous behavior, including the strict server snapshot (`initialValue` on the server, throws without one).
 
 ### What you may notice

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -4,6 +4,8 @@
 
 A React hook that returns the current/latest value from an observable. Store updates are **deferred by default** via [`useDeferredValue`](https://react.dev/reference/react/useDeferredValue): urgent renders keep the previous value while a background render catches up. That makes it safe to suspend on the returned value without replacing already-revealed UI with a Suspense fallback.
 
+The deferral is **identity-coherent**: unlike a bare `useDeferredValue(useObservable(...))`, the observable identity and its value are deferred as one snapshot, and when the observable identity changes (e.g. it is memoized on a document id that just changed) the hook falls back to the live value — typically the new observable's synchronous emission or the `initialValue` — so the previous identity's value never renders under the new one.
+
 Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash). On the server, this hook renders exactly what the client's first paint will show (a synchronous emission when there is one, else the resolved `initialValue`, else nothing) and never throws for a missing `initialValue`.
 
 Prefer this hook for previews, validation, lists, and other non-input reads. Use [`useSyncObservable`](#usesyncobservable) for controlled inputs or strict SSR control.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`useObservable` defers store updates with `useDeferredValue`, but the deferral was over the value alone. When the *observable identity* changes — e.g. the observable is memoized on a document id that just changed — the urgent render still returned the previous observable's deferred value, so the previous identity's value rendered under the new one until the deferred render caught up.

This is the same class of bug that [sanity-io/sanity#13799](https://github.com/sanity-io/sanity/pull/13799) fixed downstream with an internal `useDeferredObservableValue` helper. Per that PR's description, its semantics are how `useObservable` itself should behave, so this ports the fix into the library.

## Fix

Defer the observable identity and its value as one snapshot (`useMemo(() => ({observable, value}), [observable, value])` through `useDeferredValue`), and fall back to the live value when the deferred snapshot's observable no longer matches the current one. The live value is typically the new observable's synchronous emission or the `initialValue`, so the previous identity's value can never render under the new identity.

All other v5 semantics are preserved: the live snapshot is still passed as `useDeferredValue`'s initial value, so mounts, remounts, hidden-`<Activity>` re-renders, and reveals render the current snapshot synchronously with no initial-value flash, and SSR output still matches the first client paint.

## Changes

- `packages/react-rx/src/useObservable.ts` — identity-coherent deferred snapshot with live-value fallback on identity change
- `packages/react-rx/src/__tests__/useObservable.test.tsx` — two new render-timeline tests (sync `BehaviorSubject` switch and async `Subject` switch) asserting the render right after an identity change reflects the new observable and the old value never reappears; both fail against the previous implementation (4 failures across the plain and React Compiler projects)
- `packages/react-rx/src/__tests__/useObservablePromise.test.tsx` — widened the timing margins in the pre-existing "same-ttl preload after unmount renews share grace" test (5x scale, same assertions), which flaked on the windows-latest CI runner with only ~10ms of slack around a 40ms grace window
- `website/src/content/reference.mdx`, `website/src/content/migrate/v4-to-v5.mdx` — document the identity-coherent deferral
- `.changeset/deferred-identity-coherent.md` — patch changeset

## Verification

- `pnpm lint` clean
- `tsc -p packages/react-rx/tsconfig.json --noEmit` clean
- `pnpm test`: 32 files, 278 passed, 4 expected-fail (pre-existing), each suite run plain and through the React Compiler
- New tests confirmed to fail against the old implementation (stale `value for a` rendered under the new observable)
- `pnpm build` completes with no publint issues
- Full CI matrix green (ubuntu/macos/windows × node lts/latest)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc2f8-b5bd-7047-86ee-9c2e4bcdf68e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc2f8-b5bd-7047-86ee-9c2e4bcdf68e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

