### PR TITLE
fix(ci): keep v4 releases from latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,15 @@ jobs:
       contents: read # for checkout
       id-token: write # to enable use of OIDC for npm provenance
     secrets: inherit
+  keep-v4-release-from-latest:
+    name: Keep v4 release from becoming latest
+    needs: release
+    if: github.ref_name == 'v4'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - run: gh release edit "react-rx@$(node -p "require('./packages/react-rx/package.json').version")" --latest=false
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prevent v4 GitHub releases from replacing the v5 release from `current` as the repository's latest release.

Because this repository delegates publishing to a reusable workflow, add a dependent v4-only job that checks out the published package version and marks its `react-rx@<version>` GitHub release with `--latest=false`. The job receives only the `contents: write` permission required to edit release metadata.

## Validation

- `actionlint .github/workflows/release.yml`
- `pnpm exec oxfmt --check .github/workflows/release.yml`
- Verified the workflow's version expression resolves to the existing `react-rx@4.2.5` release tag
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-655a65eb-7368-43c5-a824-63635b5f5a10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-655a65eb-7368-43c5-a824-63635b5f5a10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

