### PR TITLE
test: sanity-driven regression coverage

### DIFF
--- a/packages/react-rx/src/__tests__/sanityConsumerContracts.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityConsumerContracts.test.tsx
@@ -1,0 +1,474 @@
+/**
+ * Regression suite for the contracts `sanity-io/sanity` builds on top of this library.
+ *
+ * The fixtures below are vendored (lightly trimmed) from sanity's core utilities:
+ *
+ * - `useLoadable` / `asLoadable` — packages/sanity/src/core/util/useLoadable.ts
+ * - `createHookFromObservableFactory` — packages/sanity/src/core/util/createHookFromObservableFactory.ts
+ *
+ * Their inline comments cite specific react-rx v5 semantics (identity-coherent deferral,
+ * shared store subscription between `useObservable` and `useSyncObservable`, error-throw
+ * timing from the live snapshot). If a change to react-rx breaks one of these tests, it
+ * breaks sanity.
+ */
+import {act, render, waitFor} from '@testing-library/react'
+import {Component, useMemo, type PropsWithChildren} from 'react'
+import {
+  catchError,
+  concat,
+  distinctUntilChanged,
+  map,
+  Observable,
+  of,
+  scan,
+  Subject,
+  switchMap,
+  type OperatorFunction,
+} from 'rxjs'
+import {describe, expect, test, vi} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+// ---------------------------------------------------------------------------
+// Vendored fixture: useLoadable (packages/sanity/src/core/util/useLoadable.ts)
+// ---------------------------------------------------------------------------
+
+interface LoadingState {
+  value: undefined
+  error: null
+  isLoading: true
+}
+
+interface LoadedState<T> {
+  value: T
+  error: null
+  isLoading: false
+}
+
+interface ErrorState {
+  value: undefined
+  error: Error
+  isLoading: false
+}
+
+type LoadableState<T> = LoadingState | LoadedState<T> | ErrorState
+
+const LOADING_STATE: LoadingState = {
+  isLoading: true,
+  value: undefined,
+  error: null,
+}
+
+function asLoadable<T>(): OperatorFunction<T, LoadableState<T>> {
+  return (value$: Observable<T>) =>
+    value$.pipe(
+      map((value) => ({isLoading: false, value, error: null}) as const),
+      catchError(
+        (error): Observable<ErrorState> => of({isLoading: false, value: undefined, error}),
+      ),
+    )
+}
+
+function useLoadable<T>(value$: Observable<T>, initialValue?: T): LoadableState<T | undefined> {
+  const initial: LoadableState<T> =
+    typeof initialValue === 'undefined'
+      ? LOADING_STATE
+      : {isLoading: false, value: initialValue, error: null}
+
+  const loadableObservable = useMemo(() => value$.pipe(asLoadable()), [value$])
+  // Sanity relies on react-rx v5's deferral being identity-coherent here: when callers
+  // key `value$` on identities like a document id, the live loadable wins on an identity
+  // change — the previous identity's loaded value never returns under the new one.
+  return useObservable(loadableObservable, initial)
+}
+
+// ---------------------------------------------------------------------------
+// Vendored fixture: createHookFromObservableFactory
+// (packages/sanity/src/core/util/createHookFromObservableFactory.ts)
+// ---------------------------------------------------------------------------
+
+type LoadingTuple<T> = [T, boolean]
+
+type ReactHook<TArgs, TResult> = (args: TArgs) => TResult
+
+function createHookFromObservableFactory<T, TArg = void>(
+  observableFactory: (arg: TArg) => Observable<T>,
+  initialValue: T,
+): ReactHook<TArg, LoadingTuple<T>>
+function createHookFromObservableFactory<T, TArg = void>(
+  observableFactory: (arg: TArg) => Observable<T>,
+  initialValue?: T,
+): ReactHook<TArg, LoadingTuple<T | undefined>>
+function createHookFromObservableFactory<T, TArg = void>(
+  observableFactory: (arg: TArg) => Observable<T>,
+  initialValue?: T,
+): ReactHook<TArg, LoadingTuple<T | undefined>> {
+  const initialLoadingTuple: LoadingTuple<T | undefined> = [initialValue, true]
+  const initialResult = {type: 'tuple', tuple: initialLoadingTuple} as const
+
+  return function useLoadableFromCreateLoadable(arg: TArg) {
+    const observable = useMemo(
+      () =>
+        of(arg).pipe(
+          switchMap((_arg) =>
+            concat(
+              of({type: 'loading'} as const),
+              observableFactory(_arg).pipe(map((value) => ({type: 'value', value}) as const)),
+            ),
+          ),
+          scan(([prevValue], next): LoadingTuple<T | undefined> => {
+            if (next.type === 'loading') return [prevValue, true]
+            return [next.value, false]
+          }, initialLoadingTuple),
+          distinctUntilChanged(([prevValue, prevIsLoading], [nextValue, nextIsLoading]) => {
+            if (prevValue !== nextValue) return false
+            if (prevIsLoading !== nextIsLoading) return false
+            return true
+          }),
+          map((tuple) => ({type: 'tuple', tuple}) as const),
+          catchError((error) => of({type: 'error', error} as const)),
+        ),
+      [arg],
+    )
+    // Sanity defers the UI tuple: on an identity change (e.g. a new document id) the
+    // identity-coherent deferral falls back to the new observable's live value — which
+    // synchronously resets to the loading tuple — so the previous arg's value never
+    // renders as loaded state for the new one.
+    const result = useObservable(observable, initialResult)
+    // Errors are thrown from the live snapshot so they reach the error boundary as soon
+    // as the observable errors, instead of after the deferred value catches up. Both
+    // hooks share one store subscription per observable, so this sync read costs no
+    // extra subscription.
+    const liveResult = useSyncObservable(observable, initialResult)
+
+    if (liveResult.type === 'error') throw liveResult.error
+    if (result.type === 'error') throw result.error
+
+    return result.tuple
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Renders `null` once a child throws; reports every caught error via `onError`.
+ * Mirrors how boundaries recover in the studio (the pane subtree remounts).
+ */
+class TestErrorBoundary extends Component<
+  PropsWithChildren<{onError: (error: Error) => void}>,
+  {hasError: boolean}
+> {
+  constructor(props: PropsWithChildren<{onError: (error: Error) => void}>) {
+    super(props)
+    this.state = {hasError: false}
+  }
+  static getDerivedStateFromError() {
+    return {hasError: true}
+  }
+  override componentDidCatch(error: Error) {
+    this.props.onError(error)
+  }
+  override render() {
+    return this.state.hasError ? null : this.props.children
+  }
+}
+
+// ---------------------------------------------------------------------------
+// createHookFromObservableFactory contracts
+// ---------------------------------------------------------------------------
+
+describe('createHookFromObservableFactory (vendored from sanity)', () => {
+  test('returns the loading tuple first, then the loaded tuple', async () => {
+    const observableFactory = (value: string) =>
+      new Observable<string>((subscriber) => {
+        tick().then(() => {
+          subscriber.next(`hello, ${value}`)
+          subscriber.complete()
+        })
+      })
+    const useHook = createHookFromObservableFactory(observableFactory)
+
+    const renderTimeline: LoadingTuple<string | undefined>[] = []
+    const TestComponent = ({value}: {value: string}) => {
+      renderTimeline.push(useHook(value))
+      return null
+    }
+    render(<TestComponent value="world" />)
+
+    expect(renderTimeline[0]).toEqual([undefined, true])
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual(['hello, world', false]))
+  })
+
+  test('with an initial value the first tuple is [initialValue, true]', async () => {
+    const observableFactory = vi.fn((value: string) =>
+      new Observable<string>((subscriber) => {
+        tick().then(() => {
+          subscriber.next(`hello, ${value}`)
+          subscriber.complete()
+        })
+      }),
+    )
+    const useHook = createHookFromObservableFactory(observableFactory, 'factory initial')
+
+    const renderTimeline: LoadingTuple<string>[] = []
+    const TestComponent = ({value}: {value: string}) => {
+      renderTimeline.push(useHook(value))
+      return null
+    }
+    render(<TestComponent value="world" />)
+
+    expect(renderTimeline[0]).toEqual(['factory initial', true])
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual(['hello, world', false]))
+    // Still a single factory call (and thus source subscription) after the value arrived.
+    expect(observableFactory).toHaveBeenCalledTimes(1)
+  })
+
+  test('arg change flips back to loading; the previous arg never renders as loaded under the new one', async () => {
+    const observableFactory = vi.fn(
+      (value: string) =>
+        new Observable<{value: string}>((subscriber) => {
+          tick().then(() => {
+            subscriber.next({value: `hello, ${value}`})
+            subscriber.complete()
+          })
+        }),
+    )
+    const useHook = createHookFromObservableFactory(observableFactory)
+
+    const renderTimeline: LoadingTuple<{value: string} | undefined>[] = []
+    const TestComponent = ({value}: {value: string}) => {
+      renderTimeline.push(useHook(value))
+      return null
+    }
+    const {rerender} = render(<TestComponent value="world" />)
+
+    expect(renderTimeline[0]).toEqual([undefined, true])
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual([{value: 'hello, world'}, false]))
+    // One factory call per distinct arg — react-rx@4.2.5 fixed a useObservable cache
+    // leak that previously caused duplicate subscriptions (and thus double calls).
+    expect(observableFactory).toHaveBeenCalledTimes(1)
+
+    const timelineLengthBeforeArgChange = renderTimeline.length
+    rerender(<TestComponent value="hooks" />)
+
+    // The first render after the arg change must be the loading tuple: the deferred
+    // snapshot belonging to the previous arg must never render as loaded state under
+    // the new identity (identity-coherent deferral).
+    expect(renderTimeline[timelineLengthBeforeArgChange]).toEqual([undefined, true])
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual([{value: 'hello, hooks'}, false]))
+    expect(renderTimeline.slice(timelineLengthBeforeArgChange)).not.toContainEqual([
+      {value: 'hello, world'},
+      false,
+    ])
+    expect(observableFactory).toHaveBeenCalledTimes(2)
+  })
+
+  test('the dual deferred + sync read costs a single source subscription', () => {
+    let activeSubscriptions = 0
+    let totalSubscriptions = 0
+    const observableFactory = () =>
+      new Observable<string>((subscriber) => {
+        activeSubscriptions += 1
+        totalSubscriptions += 1
+        subscriber.next('value')
+        return () => {
+          activeSubscriptions -= 1
+        }
+      })
+    const useHook = createHookFromObservableFactory(observableFactory)
+
+    const TestComponent = () => {
+      useHook()
+      return null
+    }
+    const {rerender} = render(<TestComponent />)
+
+    // `useObservable` and `useSyncObservable` share one store entry per observable —
+    // the warm-up probe and both live subscriptions all reuse a single source
+    // subscription.
+    expect(activeSubscriptions).toBe(1)
+    expect(totalSubscriptions).toBe(1)
+
+    rerender(<TestComponent />)
+    expect(activeSubscriptions).toBe(1)
+    expect(totalSubscriptions).toBe(1)
+  })
+
+  test('throws from the live snapshot: no stale frame is committed between the error and the boundary', async () => {
+    // The render that observes the error must throw immediately. If the throw were
+    // moved to the deferred snapshot, the error render would first commit one more
+    // frame with the stale (pre-error) tuple — deferred values lag one render behind —
+    // and only the deferred catch-up render would throw. The frame count below is the
+    // discriminating observation.
+    const subject = new Subject<string>()
+    const useHook = createHookFromObservableFactory(() => subject)
+
+    const caughtErrors: Error[] = []
+    const renderTimeline: LoadingTuple<string | undefined>[] = []
+    const TestComponent = () => {
+      renderTimeline.push(useHook())
+      return null
+    }
+    render(
+      <TestErrorBoundary onError={(error) => caughtErrors.push(error)}>
+        <TestComponent />
+      </TestErrorBoundary>,
+      {onCaughtError: () => {}},
+    )
+
+    act(() => subject.next('value before error'))
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual(['value before error', false]))
+
+    const framesBeforeError = renderTimeline.length
+    act(() => subject.error(new Error('live error')))
+
+    await waitFor(() => expect(caughtErrors.map((error) => error.message)).toContain('live error'))
+    // The erroring render threw before returning, so it committed no frame. A
+    // deferred-side throw would have appended at least one more stale
+    // `['value before error', false]` frame.
+    expect(renderTimeline.length).toBe(framesBeforeError)
+  })
+
+  test('recovers after an errored arg: the new arg loads without re-throwing or leaking stale state', async () => {
+    const subjects = new Map<string, Subject<string>>()
+    const observableFactory = vi.fn((arg: string) => {
+      if (!subjects.has(arg)) subjects.set(arg, new Subject<string>())
+      return subjects.get(arg)!
+    })
+    const useHook = createHookFromObservableFactory(observableFactory)
+
+    const caughtErrors: Error[] = []
+    const renderTimeline: LoadingTuple<string | undefined>[] = []
+    const TestComponent = ({value}: {value: string}) => {
+      renderTimeline.push(useHook(value))
+      return null
+    }
+    const view = render(
+      <TestErrorBoundary key="a" onError={(error) => caughtErrors.push(error)}>
+        <TestComponent value="a" />
+      </TestErrorBoundary>,
+      {onCaughtError: () => {}},
+    )
+
+    act(() => subjects.get('a')!.next('value for a'))
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual(['value for a', false]))
+
+    act(() => subjects.get('a')!.error(new Error('error for a')))
+    await waitFor(() => expect(caughtErrors.map((error) => error.message)).toContain('error for a'))
+
+    // Recovery: move on to arg "b". The boundary is keyed, so it remounts — the same
+    // way studio boundaries recover when the pane subtree remounts.
+    const framesBeforeRecovery = renderTimeline.length
+    const catchesBeforeRecovery = caughtErrors.length
+    view.rerender(
+      <TestErrorBoundary key="b" onError={(error) => caughtErrors.push(error)}>
+        <TestComponent value="b" />
+      </TestErrorBoundary>,
+    )
+    act(() => subjects.get('b')!.next('value for b'))
+
+    await waitFor(() => expect(renderTimeline.at(-1)).toEqual(['value for b', false]))
+    const framesAfterRecovery = renderTimeline.slice(framesBeforeRecovery)
+    // The recovery starts from b's own loading state and never renders the errored
+    // arg's data again.
+    expect(framesAfterRecovery[0]).toEqual([undefined, true])
+    expect(framesAfterRecovery).not.toContainEqual(['value for a', false])
+    // The stale error was not re-thrown into the boundary after recovery.
+    expect(caughtErrors.length).toBe(catchesBeforeRecovery)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useLoadable contracts
+// ---------------------------------------------------------------------------
+
+describe('useLoadable (vendored from sanity)', () => {
+  test('starts loading and flips to the loaded state', () => {
+    const subject = new Subject<string>()
+
+    const renderTimeline: LoadableState<string | undefined>[] = []
+    const TestComponent = ({value$}: {value$: Observable<string>}) => {
+      renderTimeline.push(useLoadable(value$))
+      return null
+    }
+    render(<TestComponent value$={subject} />)
+
+    expect(renderTimeline[0]).toEqual(LOADING_STATE)
+
+    act(() => subject.next('loaded value'))
+    expect(renderTimeline.at(-1)).toEqual({isLoading: false, value: 'loaded value', error: null})
+  })
+
+  test('an initialValue starts as already-loaded state', () => {
+    const subject = new Subject<string>()
+
+    const renderTimeline: LoadableState<string | undefined>[] = []
+    const TestComponent = ({value$}: {value$: Observable<string>}) => {
+      renderTimeline.push(useLoadable(value$, 'from cache'))
+      return null
+    }
+    render(<TestComponent value$={subject} />)
+
+    expect(renderTimeline[0]).toEqual({isLoading: false, value: 'from cache', error: null})
+
+    act(() => subject.next('fresh value'))
+    expect(renderTimeline.at(-1)).toEqual({isLoading: false, value: 'fresh value', error: null})
+  })
+
+  test('errors become error-state values via catchError — the hook never throws', () => {
+    const subject = new Subject<string>()
+
+    const renderTimeline: LoadableState<string | undefined>[] = []
+    const TestComponent = ({value$}: {value$: Observable<string>}) => {
+      renderTimeline.push(useLoadable(value$))
+      return null
+    }
+    render(<TestComponent value$={subject} />)
+
+    expect(() => {
+      act(() => subject.error(new Error('fetch failed')))
+    }).not.toThrow()
+
+    expect(renderTimeline.at(-1)).toEqual({
+      isLoading: false,
+      value: undefined,
+      error: new Error('fetch failed'),
+    })
+  })
+
+  test('identity change: the previous identity’s loaded value never renders under the new one', () => {
+    // Callers key `value$` on identities like a document id (e.g. useDocumentValues).
+    const docA = new Subject<string>()
+    const docB = new Subject<string>()
+
+    const renderTimeline: LoadableState<string | undefined>[] = []
+    const TestComponent = ({value$}: {value$: Observable<string>}) => {
+      renderTimeline.push(useLoadable(value$))
+      return null
+    }
+    const {rerender} = render(<TestComponent value$={docA} />)
+
+    act(() => docA.next('value for a'))
+    expect(renderTimeline.at(-1)).toEqual({isLoading: false, value: 'value for a', error: null})
+
+    const timelineLengthBeforeSwitch = renderTimeline.length
+    rerender(<TestComponent value$={docB} />)
+
+    // The render right after the identity change must be the new stream's live state
+    // (loading — docB has not emitted), never the deferred snapshot belonging to docA.
+    expect(renderTimeline[timelineLengthBeforeSwitch]).toEqual(LOADING_STATE)
+    expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContainEqual({
+      isLoading: false,
+      value: 'value for a',
+      error: null,
+    })
+
+    act(() => docB.next('value for b'))
+    expect(renderTimeline.at(-1)).toEqual({isLoading: false, value: 'value for b', error: null})
+  })
+})

--- a/packages/react-rx/src/__tests__/sanityConsumerContracts.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityConsumerContracts.test.tsx
@@ -66,8 +66,8 @@ function asLoadable<T>(): OperatorFunction<T, LoadableState<T>> {
   return (value$: Observable<T>) =>
     value$.pipe(
       map((value) => ({isLoading: false, value, error: null}) as const),
-      catchError(
-        (error): Observable<ErrorState> => of({isLoading: false, value: undefined, error}),
+      catchError((error): Observable<ErrorState> =>
+        of({isLoading: false, value: undefined, error}),
       ),
     )
 }
@@ -186,7 +186,7 @@ describe('createHookFromObservableFactory (vendored from sanity)', () => {
   test('returns the loading tuple first, then the loaded tuple', async () => {
     const observableFactory = (value: string) =>
       new Observable<string>((subscriber) => {
-        tick().then(() => {
+        void tick().then(() => {
           subscriber.next(`hello, ${value}`)
           subscriber.complete()
         })
@@ -205,13 +205,14 @@ describe('createHookFromObservableFactory (vendored from sanity)', () => {
   })
 
   test('with an initial value the first tuple is [initialValue, true]', async () => {
-    const observableFactory = vi.fn((value: string) =>
-      new Observable<string>((subscriber) => {
-        tick().then(() => {
-          subscriber.next(`hello, ${value}`)
-          subscriber.complete()
-        })
-      }),
+    const observableFactory = vi.fn(
+      (value: string) =>
+        new Observable<string>((subscriber) => {
+          void tick().then(() => {
+            subscriber.next(`hello, ${value}`)
+            subscriber.complete()
+          })
+        }),
     )
     const useHook = createHookFromObservableFactory(observableFactory, 'factory initial')
 
@@ -232,7 +233,7 @@ describe('createHookFromObservableFactory (vendored from sanity)', () => {
     const observableFactory = vi.fn(
       (value: string) =>
         new Observable<{value: string}>((subscriber) => {
-          tick().then(() => {
+          void tick().then(() => {
             subscriber.next({value: `hello, ${value}`})
             subscriber.complete()
           })

--- a/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
@@ -1,0 +1,504 @@
+/**
+ * Regression suite for the stream shapes `sanity-io/sanity` feeds into `useObservable` /
+ * `useSyncObservable`. Each scenario cites the sanity source it mirrors, so a failure
+ * here maps directly to studio behavior.
+ */
+import {act, render} from '@testing-library/react'
+import {useMemo} from 'react'
+import {
+  BehaviorSubject,
+  distinctUntilChanged,
+  EMPTY,
+  map,
+  NEVER,
+  Observable,
+  of,
+  shareReplay,
+  Subject,
+  take,
+} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+// ---------------------------------------------------------------------------
+// Un-memoized observables recreated on every render
+// (packages/sanity/src/core/studio/components/navbar/useCanInviteMembers.ts)
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirrors `useCanInviteMembers`: the observable is rebuilt on every render —
+ * `enabled ? store.getGrants().pipe(map(...)) : of(false)` — with no `useMemo`. The
+ * store observable replays synchronously (sanity's grants store is cached), which is
+ * what keeps the pattern stable.
+ */
+function CanInvitePane({
+  enabled,
+  grants$,
+  frames,
+}: {
+  enabled: boolean
+  grants$: Observable<string[]>
+  frames: boolean[]
+}) {
+  const result$ = grants$.pipe(map((grants) => grants.includes('invite')))
+  const canInvite$ = enabled ? result$ : of(false)
+  frames.push(useObservable(canInvite$, false))
+  return null
+}
+
+test('a new observable identity on every render stays stable when the source replays synchronously', () => {
+  let activeSubscriptions = 0
+  const grantsSubject = new BehaviorSubject<string[]>(['invite'])
+  const grants$ = new Observable<string[]>((subscriber) => {
+    activeSubscriptions += 1
+    const subscription = grantsSubject.subscribe(subscriber)
+    return () => {
+      activeSubscriptions -= 1
+      subscription.unsubscribe()
+    }
+  })
+
+  const frames: boolean[] = []
+  const {rerender, unmount} = render(
+    <CanInvitePane enabled grants$={grants$} frames={frames} />,
+  )
+
+  // The synchronous replay seeds every fresh identity's warm-up, so the value is right
+  // from the first frame and re-renders never flash the initialValue.
+  expect(frames[0]).toBe(true)
+  rerender(<CanInvitePane enabled grants$={grants$} frames={frames} />)
+  rerender(<CanInvitePane enabled grants$={grants$} frames={frames} />)
+  expect(frames.every((frame) => frame === true)).toBe(true)
+
+  // A store update flows through even though each render subscribes a new identity —
+  // and it must not trigger a render loop (each update re-renders, which rebuilds the
+  // observable, whose warm-up replays the same value and settles).
+  const framesBeforeUpdate = frames.length
+  act(() => grantsSubject.next([]))
+  expect(frames.at(-1)).toBe(false)
+  expect(frames.length - framesBeforeUpdate).toBeLessThan(10)
+
+  unmount()
+  return tick().then(() => {
+    // Every per-render subscription was cleaned up.
+    expect(activeSubscriptions).toBe(0)
+  })
+})
+
+test('the disabled branch (`of(false)` rebuilt every render) never subscribes the store and stays false', () => {
+  let storeSubscriptions = 0
+  const grants$ = new Observable<string[]>(() => {
+    storeSubscriptions += 1
+  })
+
+  const frames: boolean[] = []
+  const {rerender} = render(
+    <CanInvitePane enabled={false} grants$={grants$} frames={frames} />,
+  )
+  rerender(<CanInvitePane enabled={false} grants$={grants$} frames={frames} />)
+
+  expect(frames.every((frame) => frame === false)).toBe(true)
+  expect(storeSubscriptions).toBe(0)
+})
+
+// ---------------------------------------------------------------------------
+// EMPTY / NEVER singletons
+// (packages/sanity/src/core/user-color/hooks.ts and
+//  packages/sanity/src/core/form/utils/WithReferencedAsset.tsx)
+// ---------------------------------------------------------------------------
+
+function ObservableValueProbe({
+  observable,
+  initialValue,
+  frames,
+}: {
+  observable: Observable<string>
+  initialValue: string
+  frames: string[]
+}) {
+  frames.push(useObservable(observable, initialValue))
+  return null
+}
+
+test('the EMPTY singleton: every consumer keeps its own initialValue with no cross-contamination', async () => {
+  // `useUserColor` does `useMemo(() => (userId ? manager.listen(userId) : EMPTY), ...)`
+  // — EMPTY is a module-level singleton shared by every such hook in the app. It
+  // completes synchronously, which evicts the cache entry right away; that eviction is
+  // what keeps concurrent consumers with different initial values isolated.
+  const framesA: string[] = []
+  const framesB: string[] = []
+
+  const a = render(
+    <ObservableValueProbe observable={EMPTY} initialValue="color-a" frames={framesA} />,
+  )
+  const b = render(
+    <ObservableValueProbe observable={EMPTY} initialValue="color-b" frames={framesB} />,
+  )
+
+  expect(framesA.every((frame) => frame === 'color-a')).toBe(true)
+  expect(framesB.every((frame) => frame === 'color-b')).toBe(true)
+
+  a.rerender(<ObservableValueProbe observable={EMPTY} initialValue="color-a" frames={framesA} />)
+  expect(framesA.at(-1)).toBe('color-a')
+
+  a.unmount()
+  b.unmount()
+  await tick()
+})
+
+test('the NEVER singleton: consumers see their own initialValue and unmounting one does not disturb another', async () => {
+  // `WithReferencedAsset` swaps to NEVER when there is no document id. NEVER also is a
+  // module-level singleton, and unlike EMPTY it never terminates, so all consumers
+  // share one long-lived cache entry that must never emit anything.
+  const framesA: string[] = []
+  const framesB: string[] = []
+
+  const a = render(
+    <ObservableValueProbe observable={NEVER} initialValue="pending-a" frames={framesA} />,
+  )
+  const b = render(
+    <ObservableValueProbe observable={NEVER} initialValue="pending-b" frames={framesB} />,
+  )
+
+  expect(framesA.every((frame) => frame === 'pending-a')).toBe(true)
+  expect(framesB.every((frame) => frame === 'pending-b')).toBe(true)
+
+  a.unmount()
+  await tick()
+
+  const framesBeforeRerender = framesB.length
+  b.rerender(
+    <ObservableValueProbe observable={NEVER} initialValue="pending-b" frames={framesB} />,
+  )
+  expect(framesB.length).toBeGreaterThan(framesBeforeRerender)
+  expect(framesB.every((frame) => frame === 'pending-b')).toBe(true)
+
+  b.unmount()
+  await tick()
+})
+
+// ---------------------------------------------------------------------------
+// Completing sources: take(1) latching
+// (edit-state low-priority path in sanity's document store)
+// ---------------------------------------------------------------------------
+
+function TakeOneProbe({source$, frames}: {source$: Observable<string>; frames: string[]}) {
+  const observable = useMemo(() => source$.pipe(take(1)), [source$])
+  frames.push(useObservable(observable, 'initial'))
+  return null
+}
+
+test('a take(1) source latches the first emission and ignores everything after completion', () => {
+  const subject = new Subject<string>()
+  const frames: string[] = []
+  const {rerender} = render(<TakeOneProbe source$={subject} frames={frames} />)
+
+  expect(frames.at(-1)).toBe('initial')
+
+  act(() => subject.next('first'))
+  expect(frames.at(-1)).toBe('first')
+
+  // The observable completed with take(1); later source emissions must not update the
+  // mounted hook, and re-renders keep the latched value.
+  act(() => subject.next('second'))
+  expect(frames.at(-1)).toBe('first')
+
+  rerender(<TakeOneProbe source$={subject} frames={frames} />)
+  expect(frames.at(-1)).toBe('first')
+})
+
+// ---------------------------------------------------------------------------
+// shareReplay({bufferSize: 1, refCount: true}) sources
+// (packages/sanity/src/core/hooks/useEditState.ts and the teardown-timing contract in
+//  packages/sanity/src/structure/structureResolvers/__tests__/useResolvedPanes.test.tsx)
+// ---------------------------------------------------------------------------
+
+function EditStateProbe({
+  editState$,
+  frames,
+}: {
+  editState$: Observable<string>
+  frames: string[]
+}) {
+  // `useEditState` reads synchronously: stale edit state paired with live selection
+  // would tear (see the deferral-safety section below).
+  frames.push(useSyncObservable(editState$)!)
+  return null
+}
+
+test('a shareReplay({refCount: true}) source: one subscription while mounted, teardown deferred by a tick after unmount', async () => {
+  let activeSourceSubscriptions = 0
+  const subject = new BehaviorSubject('edit-state-1')
+  const source$ = new Observable<string>((subscriber) => {
+    activeSourceSubscriptions += 1
+    const subscription = subject.subscribe(subscriber)
+    return () => {
+      activeSourceSubscriptions -= 1
+      subscription.unsubscribe()
+    }
+  })
+  const editState$ = source$.pipe(
+    distinctUntilChanged(),
+    shareReplay({bufferSize: 1, refCount: true}),
+  )
+
+  const frames: string[] = []
+  const {rerender, unmount} = render(<EditStateProbe editState$={editState$} frames={frames} />)
+
+  expect(frames.at(-1)).toBe('edit-state-1')
+  expect(activeSourceSubscriptions).toBe(1)
+
+  // Re-renders reuse the store subscription — the source never sees churn.
+  rerender(<EditStateProbe editState$={editState$} frames={frames} />)
+  expect(activeSourceSubscriptions).toBe(1)
+
+  act(() => subject.next('edit-state-2'))
+  expect(frames.at(-1)).toBe('edit-state-2')
+
+  // useResolvedPanes.test.tsx pins this: "react-rx shares the observable and resets on
+  // refCount zero via asapScheduler, so source teardown is deferred by a tick".
+  unmount()
+  expect(activeSourceSubscriptions).toBe(1)
+  await tick()
+  expect(activeSourceSubscriptions).toBe(0)
+})
+
+test('remounting within the teardown grace keeps the source alive and replays the buffer with no loading flash', () => {
+  let totalSourceSubscriptions = 0
+  const subject = new BehaviorSubject('edit-state-1')
+  const source$ = new Observable<string>((subscriber) => {
+    totalSourceSubscriptions += 1
+    const subscription = subject.subscribe(subscriber)
+    return () => subscription.unsubscribe()
+  })
+  const editState$ = source$.pipe(
+    distinctUntilChanged(),
+    shareReplay({bufferSize: 1, refCount: true}),
+  )
+
+  const firstFrames: string[] = []
+  const first = render(<EditStateProbe editState$={editState$} frames={firstFrames} />)
+  expect(firstFrames.at(-1)).toBe('edit-state-1')
+
+  // Pane-transition shape: the old pane unmounts and the new one mounts within the
+  // same tick. The asapScheduler grace keeps the shared subscription alive, so the
+  // remount replays the buffered value synchronously — no refetch, no flash.
+  first.unmount()
+  const secondFrames: string[] = []
+  render(<EditStateProbe editState$={editState$} frames={secondFrames} />)
+
+  expect(secondFrames[0]).toBe('edit-state-1')
+  expect(totalSourceSubscriptions).toBe(1)
+})
+
+// ---------------------------------------------------------------------------
+// Render-phase warm-up blip
+// (packages/sanity/src/core/config/__tests__/bifurClientConnection.test.ts guards the
+//  WebSocket client against exactly this subscribe/unsubscribe blip)
+// ---------------------------------------------------------------------------
+
+function DisabledProbe({source$}: {source$: Observable<string>}) {
+  useObservable(source$, 'initial', {disabled: true})
+  return null
+}
+
+test('the render-phase warm-up blip hits a cold source at most once per store entry', async () => {
+  // With `disabled: true` no live store subscription follows the warm-up probe, which
+  // makes the blip observable in isolation: subscribe during render, source teardown a
+  // tick later. Consumers like bifur's WebSocket connection must tolerate this
+  // momentary zero-subscriber gap — and react-rx must not repeat it on re-renders.
+  const events: string[] = []
+  const source$ = new Observable<string>(() => {
+    events.push('subscribe')
+    return () => {
+      events.push('unsubscribe')
+    }
+  })
+
+  const {rerender} = render(<DisabledProbe source$={source$} />)
+  expect(events).toEqual(['subscribe'])
+
+  await act(async () => {
+    await tick()
+  })
+  expect(events).toEqual(['subscribe', 'unsubscribe'])
+
+  // The WeakMap entry survives the blip, so re-renders do not probe again.
+  rerender(<DisabledProbe source$={source$} />)
+  rerender(<DisabledProbe source$={source$} />)
+  expect(events).toEqual(['subscribe', 'unsubscribe'])
+})
+
+test('a mounted hook bridges the warm-up gap: the source sees a single uninterrupted subscription', () => {
+  // The counterpart: with a live subscriber the probe's refCount blip is bridged by
+  // the asapScheduler grace, so the source is subscribed exactly once with no
+  // subscribe/unsubscribe churn in between.
+  const events: string[] = []
+  const source$ = new Observable<string>((subscriber) => {
+    events.push('subscribe')
+    subscriber.next('value')
+    return () => {
+      events.push('unsubscribe')
+    }
+  })
+
+  function Probe() {
+    useObservable(source$)
+    return null
+  }
+  render(<Probe />)
+
+  expect(events).toEqual(['subscribe'])
+})
+
+// ---------------------------------------------------------------------------
+// Deferral safety: stable store observables paired with live selection state
+// (packages/sanity/src/core/perspective/__tests__/deferralSafety.test.tsx)
+// ---------------------------------------------------------------------------
+
+interface SelectionFrame {
+  name: string | undefined
+  resolved: string | undefined
+}
+
+/**
+ * The safe wiring sanity uses (useActiveReleases & friends): both the live selection
+ * and the store list are read synchronously, so a single `act` that updates both (the
+ * create-then-navigate flow) commits only coherent frames.
+ */
+function SyncSelectionProbe({
+  releases$,
+  selection$,
+  frames,
+}: {
+  releases$: Observable<string[]>
+  selection$: Observable<string | undefined>
+  frames: SelectionFrame[]
+}) {
+  const name = useSyncObservable(selection$)
+  const releases = useSyncObservable(releases$)!
+  frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
+  return null
+}
+
+/**
+ * The counterfactual sanity proved unsafe: the store list read is deferred while the
+ * selection stays live. The store observable has a stable identity for the lifetime of
+ * the workspace, so the identity-coherent fallback never engages — deferral simply
+ * makes the list lag one render behind, tearing against the live selection.
+ */
+function DeferredSelectionProbe({
+  releases$,
+  selection$,
+  frames,
+}: {
+  releases$: Observable<string[]>
+  selection$: Observable<string | undefined>
+  frames: SelectionFrame[]
+}) {
+  const name = useSyncObservable(selection$)
+  const releases = useObservable(releases$)!
+  frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
+  return null
+}
+
+test('sync reads (sanity’s wiring): no frame pairs a selected release with an unresolved id', () => {
+  const releases$ = new BehaviorSubject<string[]>([])
+  const selection$ = new BehaviorSubject<string | undefined>(undefined)
+  const frames: SelectionFrame[] = []
+
+  render(<SyncSelectionProbe releases$={releases$} selection$={selection$} frames={frames} />)
+
+  // Create release, then navigate to it in the same handler: the store emits the new
+  // release and the selection updates in one batch.
+  act(() => {
+    releases$.next(['release-1'])
+    selection$.next('release-1')
+  })
+
+  expect(frames).toContainEqual({name: 'release-1', resolved: 'release-1'})
+  expect(frames).not.toContainEqual({name: 'release-1', resolved: undefined})
+})
+
+test('deferred read of a stable store observable (counterfactual): the selection renders unresolved for a frame', () => {
+  const releases$ = new BehaviorSubject<string[]>([])
+  const selection$ = new BehaviorSubject<string | undefined>(undefined)
+  const frames: SelectionFrame[] = []
+
+  render(<DeferredSelectionProbe releases$={releases$} selection$={selection$} frames={frames} />)
+
+  act(() => {
+    releases$.next(['release-1'])
+    selection$.next('release-1')
+  })
+
+  // The tear sanity's deferralSafety suite proves: the new selection paired with the
+  // stale (empty) deferred list. This is *by design* for the deferred hook — the test
+  // pins it so the semantics cannot change silently in either direction.
+  expect(frames).toContainEqual({name: 'release-1', resolved: undefined})
+  // It converges afterwards, but consumers have already observed the torn frame.
+  expect(frames.at(-1)).toEqual({name: 'release-1', resolved: 'release-1'})
+})
+
+interface CrossFrame {
+  active: string[]
+  all: string[]
+}
+
+/** Both hooks read the very same store observable — one synchronously, one deferred. */
+function MixedSyncDeferredProbe({
+  releases$,
+  frames,
+}: {
+  releases$: Observable<string[]>
+  frames: CrossFrame[]
+}) {
+  const active = useSyncObservable(releases$)!
+  const all = useObservable(releases$)!
+  frames.push({active, all})
+  return null
+}
+
+function AllSyncProbe({
+  releases$,
+  frames,
+}: {
+  releases$: Observable<string[]>
+  frames: CrossFrame[]
+}) {
+  const active = useSyncObservable(releases$)!
+  const all = useSyncObservable(releases$)!
+  frames.push({active, all})
+  return null
+}
+
+test('two sync reads of the same store observable always agree (subset invariant)', () => {
+  const releases$ = new BehaviorSubject<string[]>([])
+  const frames: CrossFrame[] = []
+
+  render(<AllSyncProbe releases$={releases$} frames={frames} />)
+  act(() => releases$.next(['release-1']))
+
+  for (const frame of frames) {
+    expect(frame.all).toEqual(frame.active)
+  }
+  expect(frames.at(-1)).toEqual({active: ['release-1'], all: ['release-1']})
+})
+
+test('mixing a sync and a deferred read of the same store observable commits a disagreeing frame', () => {
+  const releases$ = new BehaviorSubject<string[]>([])
+  const frames: CrossFrame[] = []
+
+  render(<MixedSyncDeferredProbe releases$={releases$} frames={frames} />)
+  act(() => releases$.next(['release-1']))
+
+  // The impossible state sanity documents ("active release missing from all
+  // releases"): the sync read already has the release while the deferred read of the
+  // very same snapshot does not.
+  expect(frames).toContainEqual({active: ['release-1'], all: []})
+  expect(frames.at(-1)).toEqual({active: ['release-1'], all: ['release-1']})
+})

--- a/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
@@ -63,16 +63,14 @@ test('a new observable identity on every render stays stable when the source rep
   })
 
   const frames: boolean[] = []
-  const {rerender, unmount} = render(
-    <CanInvitePane enabled grants$={grants$} frames={frames} />,
-  )
+  const {rerender, unmount} = render(<CanInvitePane enabled grants$={grants$} frames={frames} />)
 
   // The synchronous replay seeds every fresh identity's warm-up, so the value is right
   // from the first frame and re-renders never flash the initialValue.
   expect(frames[0]).toBe(true)
   rerender(<CanInvitePane enabled grants$={grants$} frames={frames} />)
   rerender(<CanInvitePane enabled grants$={grants$} frames={frames} />)
-  expect(frames.every((frame) => frame === true)).toBe(true)
+  expect(frames.every(Boolean)).toBe(true)
 
   // A store update flows through even though each render subscribes a new identity —
   // and it must not trigger a render loop (each update re-renders, which rebuilds the
@@ -96,12 +94,10 @@ test('the disabled branch (`of(false)` rebuilt every render) never subscribes th
   })
 
   const frames: boolean[] = []
-  const {rerender} = render(
-    <CanInvitePane enabled={false} grants$={grants$} frames={frames} />,
-  )
+  const {rerender} = render(<CanInvitePane enabled={false} grants$={grants$} frames={frames} />)
   rerender(<CanInvitePane enabled={false} grants$={grants$} frames={frames} />)
 
-  expect(frames.every((frame) => frame === false)).toBe(true)
+  expect(frames.every((frame) => !frame)).toBe(true)
   expect(storeSubscriptions).toBe(0)
 })
 
@@ -171,9 +167,7 @@ test('the NEVER singleton: consumers see their own initialValue and unmounting o
   await tick()
 
   const framesBeforeRerender = framesB.length
-  b.rerender(
-    <ObservableValueProbe observable={NEVER} initialValue="pending-b" frames={framesB} />,
-  )
+  b.rerender(<ObservableValueProbe observable={NEVER} initialValue="pending-b" frames={framesB} />)
   expect(framesB.length).toBeGreaterThan(framesBeforeRerender)
   expect(framesB.every((frame) => frame === 'pending-b')).toBe(true)
 
@@ -217,13 +211,7 @@ test('a take(1) source latches the first emission and ignores everything after c
 //  packages/sanity/src/structure/structureResolvers/__tests__/useResolvedPanes.test.tsx)
 // ---------------------------------------------------------------------------
 
-function EditStateProbe({
-  editState$,
-  frames,
-}: {
-  editState$: Observable<string>
-  frames: string[]
-}) {
+function EditStateProbe({editState$, frames}: {editState$: Observable<string>; frames: string[]}) {
   // `useEditState` reads synchronously: stale edit state paired with live selection
   // would tear (see the deferral-safety section below).
   frames.push(useSyncObservable(editState$)!)

--- a/packages/react-rx/src/__tests__/useObservableEvent.strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservableEvent.strictmode.test.tsx
@@ -1,0 +1,70 @@
+import {act, renderHook} from '@testing-library/react'
+import {Observable, scan, tap} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservableEvent} from '../useObservableEvent'
+
+test('StrictMode double-mount rebuilds the pipeline: unsubscribe the first, resubscribe fresh', () => {
+  const handlerBuilds: number[] = []
+  const lifecycle: string[] = []
+
+  const {unmount} = renderHook(
+    () =>
+      useObservableEvent((events$: Observable<string>) => {
+        handlerBuilds.push(handlerBuilds.length)
+        return events$.pipe(
+          tap({
+            subscribe: () => lifecycle.push('subscribe'),
+            unsubscribe: () => lifecycle.push('unsubscribe'),
+          }),
+        )
+      }),
+    {reactStrictMode: true},
+  )
+
+  // One pipeline per effect run: mount, simulated unmount, remount.
+  expect(handlerBuilds).toHaveLength(2)
+  expect(lifecycle).toEqual(['subscribe', 'unsubscribe', 'subscribe'])
+
+  unmount()
+  expect(lifecycle).toEqual(['subscribe', 'unsubscribe', 'subscribe', 'unsubscribe'])
+})
+
+test('StrictMode delivers each event exactly once', () => {
+  const seen: string[] = []
+  const {result} = renderHook(
+    () =>
+      useObservableEvent((events$: Observable<string>) =>
+        events$.pipe(tap((value) => seen.push(value))),
+      ),
+    {reactStrictMode: true},
+  )
+
+  act(() => result.current('a'))
+  act(() => result.current('b'))
+  // Only the surviving subscription processes events — no double delivery.
+  expect(seen).toEqual(['a', 'b'])
+})
+
+test('StrictMode keeps the callback identity stable and stream state intact across the double mount', () => {
+  const totals: number[] = []
+  const {result, rerender} = renderHook(
+    () =>
+      useObservableEvent((events$: Observable<number>) =>
+        events$.pipe(
+          scan((total, n) => total + n, 0),
+          tap((total) => totals.push(total)),
+        ),
+      ),
+    {reactStrictMode: true},
+  )
+
+  const first = result.current
+  rerender()
+  expect(result.current).toBe(first)
+
+  act(() => result.current(1))
+  act(() => result.current(2))
+  // A single live scan accumulator: the discarded StrictMode pipeline left no trace.
+  expect(totals).toEqual([1, 3])
+})

--- a/packages/react-rx/src/__tests__/useObservableEvent.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservableEvent.test-d.ts
@@ -1,0 +1,40 @@
+import type {ChangeEvent} from 'react'
+import {map, type Observable} from 'rxjs'
+import {expectTypeOf, test} from 'vitest'
+
+import {useObservableEvent} from '../useObservableEvent'
+
+test('infers the event argument type from the handler observable parameter', () => {
+  const onEvent = useObservableEvent((events$: Observable<string>) =>
+    events$.pipe(map((value) => value.length)),
+  )
+  expectTypeOf(onEvent).toEqualTypeOf<(arg: string) => void>()
+})
+
+test('the returned callback returns void regardless of the pipeline output type', () => {
+  const onEvent = useObservableEvent((events$: Observable<number>) => events$.pipe(map(String)))
+  expectTypeOf(onEvent).parameter(0).toEqualTypeOf<number>()
+  expectTypeOf(onEvent).returns.toBeVoid()
+})
+
+test('the handler must return an observable', () => {
+  // @ts-expect-error - the handler must return an Observable
+  useObservableEvent((events$: Observable<string>) => 'not an observable')
+})
+
+test('void event streams produce a callback that can be called without arguments', () => {
+  const onEvent = useObservableEvent((events$: Observable<void>) => events$)
+  expectTypeOf(onEvent).toEqualTypeOf<(arg: void) => void>()
+  onEvent()
+})
+
+test('React change events flow through fully typed (DocumentListPane pattern)', () => {
+  const handleQueryChange = useObservableEvent(
+    (event$: Observable<ChangeEvent<HTMLInputElement>>) =>
+      event$.pipe(map((event) => event.target.value)),
+  )
+  expectTypeOf(handleQueryChange).parameter(0).toEqualTypeOf<ChangeEvent<HTMLInputElement>>()
+
+  // @ts-expect-error - the callback only accepts the inferred event type
+  handleQueryChange('a plain string')
+})

--- a/packages/react-rx/src/__tests__/useObservableEvent.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservableEvent.test-d.ts
@@ -19,7 +19,7 @@ test('the returned callback returns void regardless of the pipeline output type'
 
 test('the handler must return an observable', () => {
   // @ts-expect-error - the handler must return an Observable
-  useObservableEvent((events$: Observable<string>) => 'not an observable')
+  useObservableEvent((_events$: Observable<string>) => 'not an observable')
 })
 
 test('void event streams produce a callback that can be called without arguments', () => {

--- a/packages/react-rx/src/__tests__/useObservableEvent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservableEvent.test.tsx
@@ -206,19 +206,19 @@ test('events fired before the subscription effect runs are dropped (hot Subject,
   expect(seen).toEqual(['from-click'])
 })
 
-test('each hook instance gets its own isolated stream', () => {
-  const makeHook = (seen: number[]) => () =>
-    useObservableEvent((events$: Observable<number>) =>
-      events$.pipe(
-        scan((total, n) => total + n, 0),
-        tap((total) => seen.push(total)),
-      ),
-    )
+const makeAccumulatorHook = (seen: number[]) => () =>
+  useObservableEvent((events$: Observable<number>) =>
+    events$.pipe(
+      scan((total, n) => total + n, 0),
+      tap((total) => seen.push(total)),
+    ),
+  )
 
+test('each hook instance gets its own isolated stream', () => {
   const seenA: number[] = []
   const seenB: number[] = []
-  const hookA = renderHook(makeHook(seenA))
-  const hookB = renderHook(makeHook(seenB))
+  const hookA = renderHook(makeAccumulatorHook(seenA))
+  const hookB = renderHook(makeAccumulatorHook(seenB))
 
   act(() => hookA.result.current(1))
   act(() => hookB.result.current(10))
@@ -314,7 +314,7 @@ function SearchPane({queryLog}: {queryLog: string[]}) {
     (event$: Observable<ChangeEvent<HTMLInputElement>>) => {
       return event$.pipe(
         map((event) => event.target.value),
-        tap(setSearchInputValue),
+        tap((value) => setSearchInputValue(value)),
         debounce((value) => (value === '' ? of('') : timer(SEARCH_DEBOUNCE_MS))),
         tap((value) => {
           queryLog.push(value)
@@ -491,15 +491,15 @@ test('reference autocomplete: a newer search cancels the in-flight one (switchMa
   })
 })
 
-test('reference autocomplete: a failed search recovers to empty hits and later searches still work', () => {
-  const onSearch = (searchString: string) =>
-    searchString === 'fail'
-      ? new Observable<string[]>((subscriber) =>
-          subscriber.error(new Error(`search failed: ${searchString}`)),
-        )
-      : of([`hit-for-${searchString}`])
+const flakySearch = (searchString: string) =>
+  searchString === 'fail'
+    ? new Observable<string[]>((subscriber) =>
+        subscriber.error(new Error(`search failed: ${searchString}`)),
+      )
+    : of([`hit-for-${searchString}`])
 
-  const {result} = renderHook(() => useReferenceSearch(onSearch))
+test('reference autocomplete: a failed search recovers to empty hits and later searches still work', () => {
+  const {result} = renderHook(() => useReferenceSearch(flakySearch))
 
   act(() => result.current.onQueryChange('fail'))
   expect(result.current.searchState).toEqual({hits: [], searchString: 'fail', isLoading: false})

--- a/packages/react-rx/src/__tests__/useObservableEvent.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservableEvent.test.tsx
@@ -1,0 +1,514 @@
+import {act, fireEvent, render, renderHook, screen} from '@testing-library/react'
+import {memo, useCallback, useEffect, useState, type ChangeEvent} from 'react'
+import {
+  catchError,
+  concat,
+  config,
+  debounce,
+  filter,
+  map,
+  Observable,
+  of,
+  scan,
+  Subject,
+  switchMap,
+  tap,
+  timer,
+} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useObservableEvent} from '../useObservableEvent'
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+test('returns a referentially stable callback across re-renders', () => {
+  const {result, rerender} = renderHook(() =>
+    useObservableEvent((events$: Observable<string>) => events$),
+  )
+  const first = result.current
+  rerender()
+  rerender()
+  expect(result.current).toBe(first)
+})
+
+test('events flow through the pipeline in call order', () => {
+  const seen: number[] = []
+  const {result} = renderHook(() =>
+    useObservableEvent((events$: Observable<number>) =>
+      events$.pipe(
+        map((n) => n * 2),
+        tap((n) => seen.push(n)),
+      ),
+    ),
+  )
+
+  act(() => {
+    result.current(1)
+    result.current(2)
+    result.current(3)
+  })
+  expect(seen).toEqual([2, 4, 6])
+})
+
+test('builds the pipeline once: re-renders with new handler closures neither re-subscribe nor reset stream state', () => {
+  const handlerBuilds: number[] = []
+  const totals: number[] = []
+  const {result, rerender} = renderHook(() =>
+    // A new handler closure is passed on every render — the sanity codebase always
+    // passes inline arrows (e.g. DocumentListPane) and relies on the pipeline being
+    // built exactly once so debounce timers and scan accumulators survive re-renders.
+    useObservableEvent((events$: Observable<number>) => {
+      handlerBuilds.push(handlerBuilds.length)
+      return events$.pipe(
+        scan((total, n) => total + n, 0),
+        tap((total) => totals.push(total)),
+      )
+    }),
+  )
+
+  expect(handlerBuilds).toHaveLength(1)
+
+  act(() => result.current(1))
+  rerender()
+  rerender()
+  expect(handlerBuilds).toHaveLength(1)
+
+  act(() => result.current(2))
+  // The scan accumulator kept its state across the re-renders.
+  expect(totals).toEqual([1, 3])
+})
+
+test('operator closures are captured when the pipeline is built on mount, not per event', () => {
+  // Documented semantics: values captured *inside* operators freeze at subscribe time.
+  // Per-event freshness must come from the event value itself or stable stores/refs —
+  // which is why sanity's handlers only close over stable setState functions.
+  const seen: number[] = []
+  const {result, rerender} = renderHook(
+    ({factor}: {factor: number}) =>
+      useObservableEvent((events$: Observable<number>) =>
+        events$.pipe(
+          map((n) => n * factor),
+          tap((n) => seen.push(n)),
+        ),
+      ),
+    {initialProps: {factor: 2}},
+  )
+
+  act(() => result.current(1))
+  expect(seen).toEqual([2])
+
+  rerender({factor: 10})
+  act(() => result.current(1))
+  // Still the mount-time factor.
+  expect(seen).toEqual([2, 2])
+})
+
+/** Kept at module scope with the sink passed as a prop so the React Compiler captures it correctly. */
+const LabelFireButton = memo(function LabelFireButton({
+  label,
+  seen,
+}: {
+  label: string
+  seen: string[]
+}) {
+  const fire = useObservableEvent((events$: Observable<string>) =>
+    events$.pipe(tap((value) => seen.push(value))),
+  )
+  return (
+    <button type="button" onClick={() => fire(label)}>
+      fire
+    </button>
+  )
+})
+
+test('event values carry the latest render data even though operator closures are frozen', () => {
+  // The complement of the frozen-closure test: per-event data should be passed as the
+  // event value. DOM handlers close over the latest render, so this stays fresh.
+  const seen: string[] = []
+
+  const {rerender} = render(<LabelFireButton label="a" seen={seen} />)
+  fireEvent.click(screen.getByRole('button', {name: 'fire'}))
+
+  rerender(<LabelFireButton label="b" seen={seen} />)
+  fireEvent.click(screen.getByRole('button', {name: 'fire'}))
+
+  expect(seen).toEqual(['a', 'b'])
+})
+
+test('subscribes on mount and unsubscribes on unmount', () => {
+  const lifecycle: string[] = []
+  const {unmount} = renderHook(() =>
+    useObservableEvent((events$: Observable<string>) =>
+      events$.pipe(
+        tap({
+          subscribe: () => lifecycle.push('subscribe'),
+          unsubscribe: () => lifecycle.push('unsubscribe'),
+        }),
+      ),
+    ),
+  )
+
+  expect(lifecycle).toEqual(['subscribe'])
+  unmount()
+  expect(lifecycle).toEqual(['subscribe', 'unsubscribe'])
+})
+
+test('events fired after unmount are silently dropped', () => {
+  const seen: string[] = []
+  const {result, unmount} = renderHook(() =>
+    useObservableEvent((events$: Observable<string>) =>
+      events$.pipe(tap((value) => seen.push(value))),
+    ),
+  )
+
+  act(() => result.current('before'))
+  expect(seen).toEqual(['before'])
+
+  unmount()
+  // The callback itself stays callable — it just has no subscriber anymore.
+  expect(() => result.current('after')).not.toThrow()
+  expect(seen).toEqual(['before'])
+})
+
+function FireOnMountChild({fire}: {fire: () => void}) {
+  useEffect(() => {
+    fire()
+  }, [fire])
+  return null
+}
+
+/** Kept at module scope with the sink passed as a prop so the React Compiler captures it correctly. */
+function FireOnMountParent({seen}: {seen: string[]}) {
+  const call = useObservableEvent((events$: Observable<string>) =>
+    events$.pipe(tap((value) => seen.push(value))),
+  )
+  const fireFromChildMount = useCallback(() => call('from-child-mount-effect'), [call])
+  return (
+    <>
+      <FireOnMountChild fire={fireFromChildMount} />
+      <button type="button" onClick={() => call('from-click')}>
+        fire
+      </button>
+    </>
+  )
+}
+
+test('events fired before the subscription effect runs are dropped (hot Subject, no replay)', () => {
+  // Child effects run before the parent's, so an event fired from a child's mount
+  // effect happens before useObservableEvent's own effect has subscribed. This is why
+  // sanity only fires these callbacks from user events, never from mount effects.
+  const seen: string[] = []
+
+  render(<FireOnMountParent seen={seen} />)
+  expect(seen).toEqual([])
+
+  fireEvent.click(screen.getByRole('button', {name: 'fire'}))
+  expect(seen).toEqual(['from-click'])
+})
+
+test('each hook instance gets its own isolated stream', () => {
+  const makeHook = (seen: number[]) => () =>
+    useObservableEvent((events$: Observable<number>) =>
+      events$.pipe(
+        scan((total, n) => total + n, 0),
+        tap((total) => seen.push(total)),
+      ),
+    )
+
+  const seenA: number[] = []
+  const seenB: number[] = []
+  const hookA = renderHook(makeHook(seenA))
+  const hookB = renderHook(makeHook(seenB))
+
+  act(() => hookA.result.current(1))
+  act(() => hookB.result.current(10))
+  act(() => hookA.result.current(2))
+
+  // Independent scan accumulators — events never cross instances.
+  expect(seenA).toEqual([1, 3])
+  expect(seenB).toEqual([10])
+})
+
+test('a pipeline error terminates the stream: later events are dropped and the error is reported as unhandled', async () => {
+  const seen: string[] = []
+  const unhandled: unknown[] = []
+  const originalOnUnhandledError = config.onUnhandledError
+  config.onUnhandledError = (error) => unhandled.push(error)
+
+  try {
+    const {result} = renderHook(() =>
+      useObservableEvent((events$: Observable<string>) =>
+        events$.pipe(
+          map((value) => {
+            if (value === 'boom') {
+              throw new Error('boom')
+            }
+            return value
+          }),
+          tap((value) => seen.push(value)),
+        ),
+      ),
+    )
+
+    act(() => result.current('ok'))
+    expect(seen).toEqual(['ok'])
+
+    // The subscription has no error handler, so the error tears the pipeline down.
+    act(() => result.current('boom'))
+    act(() => result.current('after-error'))
+    expect(seen).toEqual(['ok'])
+
+    // RxJS reports errors from handler-less subscriptions asynchronously.
+    await act(async () => {
+      await wait(0)
+    })
+    expect(unhandled).toEqual([new Error('boom')])
+  } finally {
+    config.onUnhandledError = originalOnUnhandledError
+  }
+})
+
+test('catchError on the inner observable keeps the event stream alive', () => {
+  // The recommended pattern (and what sanity's reference inputs do): recover per
+  // request inside switchMap so one failed search does not kill the pipeline.
+  const seen: string[] = []
+  const {result} = renderHook(() =>
+    useObservableEvent((events$: Observable<string>) =>
+      events$.pipe(
+        switchMap((value) =>
+          of(value).pipe(
+            map((v) => {
+              if (v === 'fail') {
+                throw new Error('request failed')
+              }
+              return `ok:${v}`
+            }),
+            catchError(() => of('recovered')),
+          ),
+        ),
+        tap((value) => seen.push(value)),
+      ),
+    ),
+  )
+
+  act(() => result.current('a'))
+  act(() => result.current('fail'))
+  act(() => result.current('b'))
+
+  expect(seen).toEqual(['ok:a', 'recovered', 'ok:b'])
+})
+
+/**
+ * Mirrors `DocumentListPane` in sanity
+ * (packages/sanity/src/structure/panes/documentList/DocumentListPane.tsx): a controlled
+ * search input whose rendered value updates on every keystroke while the query only
+ * settles after a debounce — except clearing, which bypasses the debounce via `of('')`.
+ */
+const SEARCH_DEBOUNCE_MS = 25
+
+function SearchPane({queryLog}: {queryLog: string[]}) {
+  const [searchInputValue, setSearchInputValue] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const handleQueryChange = useObservableEvent(
+    (event$: Observable<ChangeEvent<HTMLInputElement>>) => {
+      return event$.pipe(
+        map((event) => event.target.value),
+        tap(setSearchInputValue),
+        debounce((value) => (value === '' ? of('') : timer(SEARCH_DEBOUNCE_MS))),
+        tap((value) => {
+          queryLog.push(value)
+          setSearchQuery(value)
+        }),
+      )
+    },
+  )
+
+  return (
+    <>
+      <input data-testid="search-input" value={searchInputValue} onChange={handleQueryChange} />
+      <output data-testid="search-query">{searchQuery}</output>
+    </>
+  )
+}
+
+function typeSearchValue(value: string) {
+  fireEvent.change(screen.getByTestId('search-input'), {target: {value}})
+}
+
+test('controlled search input: keystrokes update the input immediately, the query only after the debounce settles', async () => {
+  const queryLog: string[] = []
+  render(<SearchPane queryLog={queryLog} />)
+  const input = screen.getByTestId<HTMLInputElement>('search-input')
+
+  typeSearchValue('d')
+  typeSearchValue('do')
+  typeSearchValue('doc')
+
+  // tap(setSearchInputValue) runs synchronously per keystroke — the controlled input
+  // never lags, which is the whole point of the immediate/debounced split.
+  expect(input.value).toBe('doc')
+  expect(screen.getByTestId('search-query').textContent).toBe('')
+
+  await act(async () => {
+    await wait(SEARCH_DEBOUNCE_MS * 4)
+  })
+  // Only the settled value ever reached the query — no intermediate keystrokes.
+  expect(screen.getByTestId('search-query').textContent).toBe('doc')
+  expect(queryLog).toEqual(['doc'])
+})
+
+test('controlled search input: typing again during the debounce window restarts it', async () => {
+  const queryLog: string[] = []
+  render(<SearchPane queryLog={queryLog} />)
+
+  typeSearchValue('d')
+  await act(async () => {
+    // Less than the debounce window, so 'd' never settles.
+    await wait(5)
+  })
+  typeSearchValue('do')
+  await act(async () => {
+    await wait(SEARCH_DEBOUNCE_MS * 4)
+  })
+
+  expect(queryLog).toEqual(['do'])
+  expect(screen.getByTestId('search-query').textContent).toBe('do')
+})
+
+test('controlled search input: clearing bypasses the debounce and resets the query synchronously', async () => {
+  const queryLog: string[] = []
+  render(<SearchPane queryLog={queryLog} />)
+  const input = screen.getByTestId<HTMLInputElement>('search-input')
+
+  typeSearchValue('doc')
+  await act(async () => {
+    await wait(SEARCH_DEBOUNCE_MS * 4)
+  })
+  expect(screen.getByTestId('search-query').textContent).toBe('doc')
+
+  // `debounce(() => of(''))` emits synchronously, so the reset applies inside the
+  // change event itself — no waiting.
+  typeSearchValue('')
+  expect(input.value).toBe('')
+  expect(screen.getByTestId('search-query').textContent).toBe('')
+  expect(queryLog).toEqual(['doc', ''])
+})
+
+/**
+ * Mirrors `ReferenceInput` in sanity
+ * (packages/sanity/src/core/form/inputs/ReferenceInput/ReferenceInput.tsx): search terms
+ * are switchMapped into a loading notification plus an async request, folded into a
+ * single search state via scan, with per-request error recovery.
+ */
+interface ReferenceSearchState {
+  hits: string[]
+  searchString?: string
+  isLoading: boolean
+}
+
+const INITIAL_SEARCH_STATE: ReferenceSearchState = {
+  hits: [],
+  isLoading: false,
+}
+
+function nonNullable<T>(value: T): value is NonNullable<T> {
+  return value !== null
+}
+
+function useReferenceSearch(onSearch: (searchString: string) => Observable<string[]>) {
+  const [searchState, setSearchState] = useState(INITIAL_SEARCH_STATE)
+
+  const onQueryChange = useObservableEvent((inputValue$: Observable<string | null>) => {
+    return inputValue$.pipe(
+      filter(nonNullable),
+      switchMap((searchString) =>
+        concat(
+          of({isLoading: true}),
+          onSearch(searchString).pipe(
+            map((hits) => ({hits, searchString, isLoading: false})),
+            catchError(() => of({hits: [], searchString, isLoading: false})),
+          ),
+        ),
+      ),
+      scan(
+        (prevState, nextState): ReferenceSearchState => ({...prevState, ...nextState}),
+        INITIAL_SEARCH_STATE,
+      ),
+      tap(setSearchState),
+    )
+  })
+
+  return {searchState, onQueryChange}
+}
+
+test('reference autocomplete: a newer search cancels the in-flight one (switchMap) and scan folds the state', () => {
+  const requests = new Map<string, Subject<string[]>>()
+  const requestLog: string[] = []
+  const onSearch = (searchString: string) =>
+    new Observable<string[]>((subscriber) => {
+      requestLog.push(`subscribe:${searchString}`)
+      const response = new Subject<string[]>()
+      requests.set(searchString, response)
+      const subscription = response.subscribe(subscriber)
+      return () => {
+        requestLog.push(`teardown:${searchString}`)
+        subscription.unsubscribe()
+      }
+    })
+
+  const {result} = renderHook(() => useReferenceSearch(onSearch))
+  expect(result.current.searchState).toEqual(INITIAL_SEARCH_STATE)
+
+  // `filter(nonNullable)` ignores cleared inputs.
+  act(() => result.current.onQueryChange(null))
+  expect(result.current.searchState).toEqual(INITIAL_SEARCH_STATE)
+  expect(requestLog).toEqual([])
+
+  act(() => result.current.onQueryChange('foo'))
+  expect(result.current.searchState).toEqual({hits: [], isLoading: true})
+  expect(requestLog).toEqual(['subscribe:foo'])
+
+  // A newer term while 'foo' is in flight: switchMap tears 'foo' down.
+  act(() => result.current.onQueryChange('bar'))
+  expect(requestLog).toEqual(['subscribe:foo', 'teardown:foo', 'subscribe:bar'])
+  expect(result.current.searchState.isLoading).toBe(true)
+
+  // A late response for the cancelled request must not surface.
+  act(() => {
+    requests.get('foo')!.next(['foo-hit'])
+  })
+  expect(result.current.searchState.hits).toEqual([])
+
+  act(() => {
+    requests.get('bar')!.next(['bar-hit-1', 'bar-hit-2'])
+    requests.get('bar')!.complete()
+  })
+  expect(result.current.searchState).toEqual({
+    hits: ['bar-hit-1', 'bar-hit-2'],
+    searchString: 'bar',
+    isLoading: false,
+  })
+})
+
+test('reference autocomplete: a failed search recovers to empty hits and later searches still work', () => {
+  const onSearch = (searchString: string) =>
+    searchString === 'fail'
+      ? new Observable<string[]>((subscriber) =>
+          subscriber.error(new Error(`search failed: ${searchString}`)),
+        )
+      : of([`hit-for-${searchString}`])
+
+  const {result} = renderHook(() => useReferenceSearch(onSearch))
+
+  act(() => result.current.onQueryChange('fail'))
+  expect(result.current.searchState).toEqual({hits: [], searchString: 'fail', isLoading: false})
+
+  // The inner catchError kept the outer event stream alive.
+  act(() => result.current.onQueryChange('ok'))
+  expect(result.current.searchState).toEqual({
+    hits: ['hit-for-ok'],
+    searchString: 'ok',
+    isLoading: false,
+  })
+})

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -1081,9 +1081,16 @@ interface AssetReference {
   _ref?: string
 }
 
-function ReferencedAsset<Asset>(props: {
-  promise: ObservablePromise<Asset>
-  children: (assetDocument: Asset) => ReactNode
+// Concrete asset type instead of sanity's generic parameter: the observable emitting
+// `null` for missing documents is part of the tested behavior, and the concrete union
+// lets the truthiness check below narrow it.
+interface AssetDoc {
+  title: string
+}
+
+function ReferencedAsset(props: {
+  promise: ObservablePromise<AssetDoc | null>
+  children: (assetDocument: AssetDoc) => ReactNode
   waitPlaceholder?: ReactNode
 }) {
   const asset = use(props.promise)
@@ -1092,10 +1099,10 @@ function ReferencedAsset<Asset>(props: {
   return <>{asset ? props.children(asset) : props.waitPlaceholder}</>
 }
 
-function WithReferencedAsset<Asset>(props: {
+function WithReferencedAsset(props: {
   reference: AssetReference
-  observeAsset: (assetId: string) => Observable<Asset>
-  children: (assetDocument: Asset) => ReactNode
+  observeAsset: (assetId: string) => Observable<AssetDoc | null>
+  children: (assetDocument: AssetDoc) => ReactNode
   waitPlaceholder?: ReactNode
 }) {
   const {reference, children, observeAsset, waitPlaceholder} = props

--- a/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservablePromise.test.tsx
@@ -15,6 +15,9 @@ import {
 } from 'rxjs'
 import {expect, test, vi} from 'vitest'
 
+// The TTL constants are imported through the package entry point on purpose: the test
+// asserts they remain part of the public API surface.
+import {DEFAULT_HOOK_TTL, DEFAULT_PRELOAD_TTL} from '../index'
 import {
   preloadObservablePromise,
   useObservablePromise,
@@ -1057,4 +1060,225 @@ test('memoized observable is stable across parent re-renders', async () => {
     screen.getByRole('button', {name: 'tick'}).click()
   })
   expect(subscriptions).toBe(1)
+})
+
+test('the default TTL constants are public API: DEFAULT_HOOK_TTL=500, DEFAULT_PRELOAD_TTL=5000', () => {
+  // Consumers (and this package's docs) rely on these retention defaults; changing
+  // them changes refetch behavior for every hook call without an explicit ttl.
+  expect(DEFAULT_HOOK_TTL).toBe(500)
+  expect(DEFAULT_PRELOAD_TTL).toBe(5000)
+})
+
+// ---------------------------------------------------------------------------
+// The WithReferencedAsset pattern, vendored from sanity
+// (packages/sanity/src/core/form/utils/WithReferencedAsset.tsx): swap to the NEVER
+// singleton and `disabled: true` when there is no document id, keep the placeholder up
+// for falsy emissions, and key the promise to the observable identity so a reference
+// change never shows the previous document's asset.
+// ---------------------------------------------------------------------------
+
+interface AssetReference {
+  _ref?: string
+}
+
+function ReferencedAsset<Asset>(props: {
+  promise: ObservablePromise<Asset>
+  children: (assetDocument: Asset) => ReactNode
+  waitPlaceholder?: ReactNode
+}) {
+  const asset = use(props.promise)
+  // observeAsset implementations emit null while the referenced document is missing or
+  // not yet indexed — keep the placeholder up for falsy emissions.
+  return <>{asset ? props.children(asset) : props.waitPlaceholder}</>
+}
+
+function WithReferencedAsset<Asset>(props: {
+  reference: AssetReference
+  observeAsset: (assetId: string) => Observable<Asset>
+  children: (assetDocument: Asset) => ReactNode
+  waitPlaceholder?: ReactNode
+}) {
+  const {reference, children, observeAsset, waitPlaceholder} = props
+  const documentId = reference?._ref
+  // Never invoke `observeAsset` without an id: some implementations parse the id
+  // synchronously at call time and would throw during render.
+  const observable = useMemo(
+    () => (documentId ? observeAsset(documentId) : NEVER),
+    [documentId, observeAsset],
+  )
+  const promise = useObservablePromise(observable, {disabled: !documentId})
+  if (!documentId) {
+    return <>{waitPlaceholder}</>
+  }
+  return (
+    <Suspense fallback={waitPlaceholder}>
+      <ReferencedAsset promise={promise} waitPlaceholder={waitPlaceholder}>
+        {children}
+      </ReferencedAsset>
+    </Suspense>
+  )
+}
+
+function Placeholder() {
+  return <div data-testid="placeholder">wait</div>
+}
+
+function AssetTitle({title}: {title: string}) {
+  return <div data-testid="asset">{title}</div>
+}
+
+test('WithReferencedAsset without a reference: placeholder renders, observeAsset is never called, nothing fetches', async () => {
+  const observeAsset = vi.fn((id: string) => of({title: `asset ${id}`}))
+
+  const {rerender} = await renderAsync(
+    <WithReferencedAsset
+      reference={{}}
+      observeAsset={observeAsset}
+      waitPlaceholder={<Placeholder />}
+    >
+      {(asset) => <AssetTitle title={asset.title} />}
+    </WithReferencedAsset>,
+  )
+
+  expect(screen.getByTestId('placeholder')).toBeTruthy()
+  expect(screen.queryByTestId('asset')).toBeNull()
+  expect(observeAsset).not.toHaveBeenCalled()
+
+  // Re-renders keep hitting the NEVER + disabled path without starting anything.
+  rerender(
+    <WithReferencedAsset
+      reference={{}}
+      observeAsset={observeAsset}
+      waitPlaceholder={<Placeholder />}
+    >
+      {(asset) => <AssetTitle title={asset.title} />}
+    </WithReferencedAsset>,
+  )
+  expect(observeAsset).not.toHaveBeenCalled()
+})
+
+test('assigning a reference flips disabled off: suspends into the placeholder, then shows the asset', async () => {
+  const responses = new Map<string, Subject<{title: string} | null>>()
+  let sourceSubscriptions = 0
+  const observeAsset = vi.fn(
+    (id: string) =>
+      new Observable<{title: string} | null>((subscriber) => {
+        sourceSubscriptions++
+        if (!responses.has(id)) {
+          responses.set(id, new Subject())
+        }
+        const subscription = responses.get(id)!.subscribe(subscriber)
+        return () => subscription.unsubscribe()
+      }),
+  )
+
+  const view = await renderAsync(
+    <WithReferencedAsset
+      reference={{}}
+      observeAsset={observeAsset}
+      waitPlaceholder={<Placeholder />}
+    >
+      {(asset) => <AssetTitle title={asset.title} />}
+    </WithReferencedAsset>,
+  )
+  expect(observeAsset).not.toHaveBeenCalled()
+
+  // The reference gets a _ref: the observable swaps from NEVER to the real source and
+  // `disabled` flips to false in the same render.
+  await act(async () => {
+    view.rerender(
+      <WithReferencedAsset
+        reference={{_ref: 'image-1'}}
+        observeAsset={observeAsset}
+        waitPlaceholder={<Placeholder />}
+      >
+        {(asset) => <AssetTitle title={asset.title} />}
+      </WithReferencedAsset>,
+    )
+  })
+
+  expect(observeAsset).toHaveBeenCalledTimes(1)
+  expect(sourceSubscriptions).toBe(1)
+  // Pending: the Suspense boundary shows the placeholder.
+  expect(screen.getByTestId('placeholder')).toBeTruthy()
+  expect(screen.queryByTestId('asset')).toBeNull()
+
+  // A null emission (missing / not yet indexed document) fulfills the promise but the
+  // consumer keeps the placeholder up.
+  await act(async () => {
+    responses.get('image-1')!.next(null)
+  })
+  expect(screen.getByTestId('placeholder')).toBeTruthy()
+  expect(screen.queryByTestId('asset')).toBeNull()
+
+  // The real asset arrives: content swaps in with no re-suspension.
+  await act(async () => {
+    responses.get('image-1')!.next({title: 'first title'})
+  })
+  await waitFor(() => expect(screen.getByTestId('asset').textContent).toBe('first title'))
+
+  // Later emissions keep updating without going back to the placeholder.
+  await act(async () => {
+    responses.get('image-1')!.next({title: 'updated title'})
+  })
+  expect(screen.getByTestId('asset').textContent).toBe('updated title')
+  expect(screen.queryByTestId('placeholder')).toBeNull()
+
+  // Still a single observeAsset call / subscription for the whole lifecycle.
+  expect(observeAsset).toHaveBeenCalledTimes(1)
+  expect(sourceSubscriptions).toBe(1)
+})
+
+test('changing the reference never renders the previous asset under the new one', async () => {
+  const responses = new Map<string, Subject<{title: string} | null>>()
+  const observeAsset = vi.fn(
+    (id: string) =>
+      new Observable<{title: string} | null>((subscriber) => {
+        if (!responses.has(id)) {
+          responses.set(id, new Subject())
+        }
+        const subscription = responses.get(id)!.subscribe(subscriber)
+        return () => subscription.unsubscribe()
+      }),
+  )
+
+  const view = await renderAsync(
+    <WithReferencedAsset
+      reference={{_ref: 'image-1'}}
+      observeAsset={observeAsset}
+      waitPlaceholder={<Placeholder />}
+    >
+      {(asset) => <AssetTitle title={asset.title} />}
+    </WithReferencedAsset>,
+  )
+  await act(async () => {
+    responses.get('image-1')!.next({title: 'asset one'})
+  })
+  await waitFor(() => expect(screen.getByTestId('asset').textContent).toBe('asset one'))
+
+  // Point the reference at another document. The promise is keyed to the observable
+  // identity (and thereby the id), so the boundary re-suspends into the placeholder.
+  // React keeps the previously revealed content in the DOM but hides it
+  // (display: none) — the previous document's asset is never *visible* under the new
+  // reference.
+  await act(async () => {
+    view.rerender(
+      <WithReferencedAsset
+        reference={{_ref: 'image-2'}}
+        observeAsset={observeAsset}
+        waitPlaceholder={<Placeholder />}
+      >
+        {(asset) => <AssetTitle title={asset.title} />}
+      </WithReferencedAsset>,
+    )
+  })
+  expect(screen.getByTestId('placeholder')).toBeTruthy()
+  expect(screen.getByTestId('asset').style.display).toBe('none')
+
+  await act(async () => {
+    responses.get('image-2')!.next({title: 'asset two'})
+  })
+  await waitFor(() => expect(screen.getByTestId('asset').textContent).toBe('asset two'))
+  expect(screen.getByTestId('asset').style.display).not.toBe('none')
+  expect(observeAsset).toHaveBeenCalledTimes(2)
 })

--- a/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
@@ -1,0 +1,301 @@
+import {act, render, screen} from '@testing-library/react'
+import {Activity, useState, type ReactNode} from 'react'
+import {defer, from, Observable, of, Subject} from 'rxjs'
+import {expect, test} from 'vitest'
+
+import {useSyncObservable} from '../useSyncObservable'
+
+/**
+ * `<Activity>` parity suite for `useSyncObservable` — the synchronous counterpart of
+ * `useObservable.activity.test.tsx`. Sanity reads edit state, validation, and other
+ * write-gating values through the sync hook inside panes that get hidden, so the same
+ * hide/show guarantees must hold without the deferral layer:
+ *
+ * - `<Activity mode="hidden">` tears down the `useSyncExternalStore` subscription and
+ *   re-creates it on reveal, while React state / the last rendered UI are preserved.
+ * - The render-phase warm-up probe still seeds synchronous emissions into the WeakMap
+ *   cache even when Activity has not mounted a live subscription yet.
+ * - The cache entry keeps `didEmit` / `snapshot` across hidden re-renders, so revealed
+ *   panes resume from the last emission instead of the `initialValue`.
+ */
+
+function ToggleActivity({children}: {children: ReactNode}) {
+  const [mode, setMode] = useState<'visible' | 'hidden'>('visible')
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setMode((m) => (m === 'visible' ? 'hidden' : 'visible'))}
+      >
+        toggle
+      </button>
+      <Activity mode={mode}>{children}</Activity>
+    </>
+  )
+}
+
+async function toggle() {
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+  // `share({resetOnRefCountZero: () => timer(0, asapScheduler)})` delays teardown
+  await Promise.resolve()
+}
+
+function textOf(testId: string) {
+  return screen.getByTestId(testId).textContent
+}
+
+test('Activity hides and restores useSyncObservable subscriptions the same way it does Effects', async () => {
+  const events: string[] = []
+  const observable = new Observable<string>((subscriber) => {
+    events.push('subscribe')
+    subscriber.next('value')
+    return () => {
+      events.push('unsubscribe')
+    }
+  })
+
+  function Child() {
+    return <div data-testid="value">{useSyncObservable(observable)}</div>
+  }
+
+  render(
+    <ToggleActivity>
+      <Child />
+    </ToggleActivity>,
+  )
+
+  expect(events).toEqual(['subscribe'])
+  expect(textOf('value')).toBe('value')
+
+  await toggle()
+  expect(events).toEqual(['subscribe', 'unsubscribe'])
+  // Last rendered value is preserved while hidden (display:none).
+  expect(textOf('value')).toBe('value')
+  expect(screen.getByTestId('value').style.display).toBe('none')
+
+  await toggle()
+  expect(events).toEqual(['subscribe', 'unsubscribe', 'subscribe'])
+  expect(textOf('value')).toBe('value')
+  expect(screen.getByTestId('value').style.display).not.toBe('none')
+})
+
+test('sync observable with initial value: sync emission wins over initial, including across Activity toggles', async () => {
+  const observable = of('sync')
+
+  function Child() {
+    return <div data-testid="value">{useSyncObservable(observable, 'initial')}</div>
+  }
+
+  render(
+    <ToggleActivity>
+      <Child />
+    </ToggleActivity>,
+  )
+
+  expect(textOf('value')).toBe('sync')
+
+  await toggle()
+  expect(textOf('value')).toBe('sync')
+
+  await toggle()
+  expect(textOf('value')).toBe('sync')
+})
+
+test('async observable with initial value: emissions while Activity is hidden are dropped until visible again', async () => {
+  const subject = new Subject<string>()
+  let subscriptions = 0
+  const observable = new Observable<string>((subscriber) => {
+    subscriptions++
+    const subscription = subject.subscribe(subscriber)
+    return () => subscription.unsubscribe()
+  })
+
+  function Child() {
+    return <div data-testid="value">{useSyncObservable(observable, 'initial')}</div>
+  }
+
+  render(
+    <ToggleActivity>
+      <Child />
+    </ToggleActivity>,
+  )
+
+  expect(textOf('value')).toBe('initial')
+  act(() => subject.next('visible-1'))
+  expect(textOf('value')).toBe('visible-1')
+  expect(subscriptions).toBe(1)
+
+  await toggle()
+  expect(subscriptions).toBe(1)
+  expect(textOf('value')).toBe('visible-1')
+
+  // No live subscription while hidden — this emission is dropped.
+  act(() => subject.next('hidden-missed'))
+  expect(textOf('value')).toBe('visible-1')
+
+  await toggle()
+  expect(subscriptions).toBe(2)
+  // Last value from before hide is still shown; the missed emission never arrived.
+  expect(textOf('value')).toBe('visible-1')
+
+  act(() => subject.next('visible-2'))
+  expect(textOf('value')).toBe('visible-2')
+})
+
+test('async fetch that resolves while Activity is hidden: value appears when becoming visible again', async () => {
+  let resolve!: (value: string) => void
+  const promise = new Promise<string>((r) => {
+    resolve = r
+  })
+  const observable = defer(() => from(promise))
+
+  function Child() {
+    return <div data-testid="value">{useSyncObservable(observable, 'initial')}</div>
+  }
+
+  render(
+    <ToggleActivity>
+      <Child />
+    </ToggleActivity>,
+  )
+
+  expect(textOf('value')).toBe('initial')
+
+  await toggle()
+  // Resolve while unsubscribed / hidden.
+  await act(async () => {
+    resolve('fetched-while-hidden')
+    await promise
+  })
+  // Still showing the pre-hide snapshot — no subscription to receive the emission.
+  expect(textOf('value')).toBe('initial')
+
+  await toggle()
+  // Re-subscribe hits `from(alreadyResolvedPromise)`, which emits synchronously.
+  expect(textOf('value')).toBe('fetched-while-hidden')
+})
+
+test('Activity initially hidden: no live subscription until visible; sync probe still seeds the snapshot', async () => {
+  let activeSubscriptions = 0
+  const observable = new Observable<string>((subscriber) => {
+    activeSubscriptions++
+    subscriber.next('sync')
+    return () => {
+      activeSubscriptions--
+    }
+  })
+
+  function Child() {
+    return <div data-testid="value">{useSyncObservable(observable, 'initial')}</div>
+  }
+
+  const {rerender} = render(
+    <Activity mode="hidden">
+      <Child />
+    </Activity>,
+  )
+
+  // Eager render-time probe subscribed then the shared refcount dropped (no uSES listener yet).
+  await act(async () => {
+    await Promise.resolve()
+  })
+  expect(activeSubscriptions).toBe(0)
+  // Snapshot still holds the sync emission from the probe; DOM is display:none.
+  expect(textOf('value')).toBe('sync')
+  expect(screen.getByTestId('value').style.display).toBe('none')
+
+  rerender(
+    <Activity mode="visible">
+      <Child />
+    </Activity>,
+  )
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  expect(activeSubscriptions).toBeGreaterThan(0)
+  expect(textOf('value')).toBe('sync')
+})
+
+/** Kept at module scope so identity is stable across App re-renders. */
+function HiddenRerenderProbe({
+  label,
+  observable,
+  log,
+}: {
+  label: string
+  observable: Observable<string>
+  log: string[]
+}) {
+  const value = useSyncObservable(observable, 'initial')
+  log.push(value)
+  return (
+    <div data-testid="value">
+      {label}:{value}
+    </div>
+  )
+}
+
+function HiddenRerenderApp({observable, log}: {observable: Observable<string>; log: string[]}) {
+  const [mode, setMode] = useState<'visible' | 'hidden'>('visible')
+  const [label, setLabel] = useState('a')
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setMode((m) => (m === 'visible' ? 'hidden' : 'visible'))}
+      >
+        toggle
+      </button>
+      <button type="button" onClick={() => setLabel('b')}>
+        relabel
+      </button>
+      <Activity mode={mode}>
+        <HiddenRerenderProbe label={label} observable={observable} log={log} />
+      </Activity>
+    </>
+  )
+}
+
+test('hidden re-renders and the reveal keep the cached emission, never the initialValue', async () => {
+  // The WeakMap cache entry keeps `didEmit` / `snapshot` while the subscription is torn
+  // down, so a hidden re-render (forced by a parent update) reads the last emission
+  // from `getSnapshot` — not the `initialValue`.
+  const subject = new Subject<string>()
+  const log: string[] = []
+
+  render(<HiddenRerenderApp observable={subject} log={log} />)
+  act(() => subject.next('emitted'))
+  expect(textOf('value')).toBe('a:emitted')
+
+  // Hide: the store subscription tears down but the WeakMap cache entry survives.
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+  await Promise.resolve()
+  expect(screen.getByTestId('value').style.display).toBe('none')
+
+  log.length = 0
+  // Parent update re-renders the hidden tree (lower priority — give React a turn to flush).
+  await act(async () => {
+    screen.getByRole('button', {name: 'relabel'}).click()
+  })
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  expect(log.length).toBeGreaterThan(0)
+  expect(log).not.toContain('initial')
+  expect(textOf('value')).toBe('b:emitted')
+
+  // Reveal: the preserved tree still shows the cached snapshot.
+  await act(async () => {
+    screen.getByRole('button', {name: 'toggle'}).click()
+  })
+  await Promise.resolve()
+  expect(textOf('value')).toBe('b:emitted')
+  expect(screen.getByTestId('value').style.display).not.toBe('none')
+  expect(log).not.toContain('initial')
+  expect(log.every((v) => v === 'emitted')).toBe(true)
+})

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -397,3 +397,35 @@ test('should return the actual value when the hook is disabled and then re-enabl
 
   unmount()
 })
+
+test('initialValue factories must be pure', () => {
+  const values$ = new Subject<string>()
+  let factoryCalls = 0
+  const factory = () => {
+    factoryCalls++
+    return 'initial'
+  }
+
+  const {result} = renderHook(() => useSyncObservable(values$, factory))
+  // Pre-emission: uSES calls getSnapshot (factory included) during render and again
+  // when checking for tearing on commit.
+  expect(factoryCalls).toBeGreaterThanOrEqual(2)
+  expect(result.current).toBe('initial')
+  const callsBeforeEmit = factoryCalls
+
+  act(() => values$.next('emitted'))
+  expect(result.current).toBe('emitted')
+  // After didEmit, getSnapshot short-circuits and the factory is no longer called.
+  expect(factoryCalls).toBe(callsBeforeEmit)
+})
+
+test('SSR resolves a factory initialValue through getServerSnapshot', () => {
+  // The sync hook's getServerSnapshot resolves factories via getValue — a code path
+  // distinct from the client getSnapshot.
+  const observable = scheduled('async value', asyncScheduler)
+  function ObservableComponent() {
+    return <>{useSyncObservable(observable, () => 'factory initial')}</>
+  }
+
+  expect(renderToString(<ObservableComponent />)).toBe('factory initial')
+})

--- a/packages/react-rx/vitest.config.ts
+++ b/packages/react-rx/vitest.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
         plugins: [react()],
         test: {
           name: 'default',
+          typecheck: {
+            // The CLI `--typecheck` flag does not reach project configs, so the type
+            // tests (`*.test-d.ts`) must be enabled here to actually run. Only this
+            // project runs them — the react-compiler project only changes the runtime
+            // transform, which type tests never see.
+            enabled: true,
+            ignoreSourceErrors: true,
+          },
         },
       },
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds regression test suites that mirror how [`sanity-io/sanity`](https://github.com/sanity-io/sanity) (130 files importing `react-rx@5.1.1`, React 19.2 + React Compiler) actually consumes this library, so regressions in the contracts sanity depends on are caught before a release.

Suite growth: **36 → 46 test files, 316 → 402 passing tests** (each runtime suite runs under both the `default` and `react-compiler` Vitest projects), and the type tests now actually execute.

## Changes

### Fix: `*.test-d.ts` type tests were silently skipped

The CLI `--typecheck` flag does not propagate into vitest project configs, so no type test was running — a deliberate type error passed the full suite. Typecheck is now enabled in the `default` project in `packages/react-rx/vitest.config.ts` (the `react-compiler` project only changes the runtime transform, which type tests never see).

### `useObservableEvent`: full coverage (previously zero tests)

`useObservableEvent.test.tsx`, `useObservableEvent.strictmode.test.tsx`, `useObservableEvent.test-d.ts`:

- Stable callback identity; events flow in order; pipeline built exactly once so re-renders with new inline handlers never reset debounce timers or `scan` state (what sanity's search inputs rely on).
- Operator closures freeze at mount vs. event values carrying the latest render data (both directions pinned).
- Subscription lifecycle, pre-mount and post-unmount event drops, per-instance stream isolation.
- Error semantics: an unhandled pipeline error terminates the stream and reports via RxJS `config.onUnhandledError`; inner `catchError` keeps the stream alive.
- Faithful fixtures: `DocumentListPane`'s debounced controlled search input (immediate input value, debounced query, synchronous clear) and `ReferenceInput`'s `switchMap` + `scan` autocomplete (in-flight cancellation, late-response suppression, per-request error recovery).
- StrictMode double-mount: pipeline rebuilt, single delivery, clean teardown.

### `sanityConsumerContracts.test.tsx`

Vendors sanity's `useLoadable` and `createHookFromObservableFactory` and asserts the react-rx semantics their comments cite: loading-tuple flips, identity-coherent deferral on arg change (previous arg's loaded value never paints), a single shared source subscription for the dual deferred + sync read, live-snapshot error-throw timing (no stale frame before the boundary), post-error recovery, and `catchError`-into-value loadable states.

### `sanityStreamShapes.test.tsx`

The stream shapes sanity feeds in: un-memoized observables rebuilt every render staying stable off sync-replaying sources (`useCanInviteMembers`), `EMPTY`/`NEVER` singleton isolation between consumers, `take(1)` latching, `shareReplay({refCount: true})` single-subscription reuse with asap-deferred teardown and remount-within-grace buffer replay (`useEditState`, `useResolvedPanes`), the render-phase warm-up blip hitting cold sources at most once (the bifur WebSocket concern), and the deferral-safety contract from sanity's `deferralSafety.test.tsx` (sync reads stay coherent; deferred reads of stable store observables tear for one frame by design).

### `useSyncObservable` parity

New `<Activity>` hide/show suite (sanity reads edit state and validation through the sync hook inside panes that get hidden), plus `initialValue` factory-purity and the SSR `getServerSnapshot` factory-resolution path.

### `useObservablePromise` gaps

The `WithReferencedAsset` composite (`NEVER` + `disabled` without a document id, the disabled-to-enabled flip, null emissions keeping the placeholder, reference changes never showing the previous asset) and `DEFAULT_HOOK_TTL`/`DEFAULT_PRELOAD_TTL` pinned as public API via the package entry point.

## Test plan

- `pnpm test` — 46 files, 402 passed + 4 expected-fail, type errors: none
- `pnpm lint`, `pnpm knip`, `oxfmt --check` — clean
- `pnpm build` + `tsc -p packages/react-rx/tsconfig.json --noEmit` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4fb7a4f2-8056-4926-8fba-88be9b3dd116?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fb7a4f2-8056-4926-8fba-88be9b3dd116&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

