### PR TITLE
feat!: require the initialValue argument in useObservable and useSyncObservable

### DIFF
--- a/.changeset/require-initial-value.md
+++ b/.changeset/require-initial-value.md
@@ -1,0 +1,24 @@
+---
+"react-rx": major
+---
+
+**Breaking:** `useObservable` and `useSyncObservable` now require the `initialValue` argument.
+
+The initial value is what renders until the observable emits. Omitting the argument is a type error, and — since JavaScript callers can bypass the types — the hooks also detect a missing argument at runtime (internally defaulting it to the `Symbol.for('react-rx.unsetInitialValue')` sentinel) and throw during render.
+
+The rules for what counts as a valid `initialValue`:
+
+- **Every value is valid, `undefined` included** — but it must be passed explicitly: `useObservable(value$, undefined)` renders `undefined` until the first emission, while `useObservable(value$)` throws.
+- **Functions act as initializers**, exactly like `useState`: `useObservable(value$, () => expensiveInitial())` computes the initial value lazily. To use a function itself as the initial value, pass an initializer that returns it: `useObservable(fn$, () => myFunction)`.
+
+Migration:
+
+- Call sites that already pass an `initialValue` are unaffected, including their runtime behavior.
+- For call sites that relied on `undefined` being the implicit initial value, pass it explicitly: `useObservable(value$)` → `useObservable(value$, undefined)`.
+- Call sites that relied on the render-phase warm-up subscription (with no `initialValue`, a synchronous emission — e.g. from `of`, `startWith`, or a `BehaviorSubject` — used to be returned from the very first render): there is no warm-up on mount anymore. The first render shows the `initialValue` and the synchronous emission replaces it right after mount, in the same paint cycle as with any other emission. If an observable has no initial value that makes sense, or you want fallback UI while the observable is "loading", use `useObservablePromise` with `use()` and Suspense instead.
+
+This dramatically simplifies the internal implementation and makes the hooks' behavior uniform:
+
+- The observable is **never** subscribed during render for its first paint — subscribe-time side effects (network requests, socket connections) can no longer run as render-phase side effects. The only remaining render-phase warm-up is for replacement observables after the hook has received an emission, which is what keeps consumers that rebuild the observable on every render from looping forever.
+- `disabled: true` now always guarantees zero subscriptions (previously the warm-up probe still subscribed once when no `initialValue` was given).
+- Server rendering is uniform: both hooks render the resolved `initialValue` and never subscribe the observable, so `useSyncObservable` no longer hits React's "Missing getServerSnapshot" error and non-deterministic synchronous emissions can no longer cause hydration mismatches.

--- a/packages/react-rx/README.md
+++ b/packages/react-rx/README.md
@@ -6,8 +6,9 @@
 
 Features:
 
-- Works well with Observables emitting values synchronously. You don't pay the re-render-on-mount tax.
+- Predictable first paint — the required `initialValue` renders first, and observables are never subscribed during render (no render-phase side effects, server included).
 - Non-blocking by default — `useObservable` defers store updates; reach for `useSyncObservable` for controlled inputs.
+- Suspense-ready — `useObservablePromise` turns an observable into a `use()`-compatible promise for when there is no meaningful initial value.
 - Lightweight. Implemented on top of a small React Hook based core.
 - Full TypeScript support.
 

--- a/packages/react-rx/src/__tests__/requiredInitialValue.test.tsx
+++ b/packages/react-rx/src/__tests__/requiredInitialValue.test.tsx
@@ -1,0 +1,95 @@
+import {act, render, renderHook} from '@testing-library/react'
+import {renderToString} from 'react-dom/server'
+import {Observable, of, Subject} from 'rxjs'
+import {describe, expect, test} from 'vitest'
+
+import {useObservable} from '../useObservable'
+import {useSyncObservable} from '../useSyncObservable'
+
+/**
+ * `initialValue` is a required argument for `useObservable` and `useSyncObservable`. Omission is
+ * detected by argument arity (the internal default is the `Symbol.for('react-rx.unsetInitialValue')`
+ * sentinel) and throws during render, because every value a caller can pass — `undefined`
+ * included — is a valid initial value. Observables without a meaningful initial value belong to
+ * `useObservablePromise` instead.
+ */
+
+const hooks = [
+  {name: 'useObservable', useHook: useObservable},
+  {name: 'useSyncObservable', useHook: useSyncObservable},
+] as const
+
+const double = (n: number) => n * 2
+const triple = (n: number) => n * 3
+
+describe.each(hooks)('$name: initialValue is required', ({name, useHook}) => {
+  test('omitting the initialValue throws during render', () => {
+    const observable = of('sync')
+    function ObservableComponent() {
+      // @ts-expect-error - initialValue is required; the runtime must throw as well
+      return <>{useHook(observable)}</>
+    }
+
+    expect(() => render(<ObservableComponent />)).toThrow(`${name} requires an initialValue`)
+  })
+
+  test('omitting the initialValue throws during server rendering too', () => {
+    const observable = of('sync')
+    function ObservableComponent() {
+      // @ts-expect-error - initialValue is required; the runtime must throw as well
+      return <>{useHook(observable)}</>
+    }
+
+    expect(() => renderToString(<ObservableComponent />)).toThrow(
+      `${name} requires an initialValue`,
+    )
+  })
+
+  test('the throw happens before the observable is touched: nothing subscribes', () => {
+    let subscriptions = 0
+    const observable = new Observable<string>(() => {
+      subscriptions++
+    })
+    function ObservableComponent() {
+      // @ts-expect-error - initialValue is required; the runtime must throw as well
+      return <>{useHook(observable)}</>
+    }
+
+    expect(() => render(<ObservableComponent />)).toThrow(`${name} requires an initialValue`)
+    expect(subscriptions).toBe(0)
+  })
+
+  test('an explicit undefined is a valid initialValue: renders undefined until the observable emits', () => {
+    const values$ = new Subject<string>()
+    const {result, unmount} = renderHook(() => useHook(values$, undefined))
+
+    expect(result.current).toBeUndefined()
+
+    act(() => values$.next('emitted'))
+    expect(result.current).toBe('emitted')
+    unmount()
+  })
+
+  test('an explicit undefined initialValue renders on the server without throwing', () => {
+    const values$ = new Subject<string>()
+    function ObservableComponent() {
+      return <>{useHook(values$, undefined) ?? 'nothing yet'}</>
+    }
+
+    expect(renderToString(<ObservableComponent />)).toBe('nothing yet')
+  })
+
+  test('functions act as initializers, like useState: an initializer returning a function makes that function the initial value', () => {
+    const fns$ = new Subject<(n: number) => number>()
+    const {result, unmount} = renderHook(() => useHook(fns$, () => double))
+
+    // The initializer itself is called (useState semantics); its return value is the initial value.
+    expect(result.current).toBe(double)
+    expect(result.current(4)).toBe(8)
+
+    act(() => fns$.next(triple))
+    // Emitted functions are returned as-is — only the initialValue goes through the initializer.
+    expect(result.current).toBe(triple)
+    unmount()
+  })
+})

--- a/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
+++ b/packages/react-rx/src/__tests__/sanityStreamShapes.test.tsx
@@ -262,7 +262,7 @@ test('a take(1) source latches the first emission and ignores everything after c
 function EditStateProbe({editState$, frames}: {editState$: Observable<string>; frames: string[]}) {
   // `useEditState` reads synchronously: stale edit state paired with live selection
   // would tear (see the deferral-safety section below).
-  frames.push(useSyncObservable(editState$)!)
+  frames.push(useSyncObservable(editState$, undefined)!)
   return null
 }
 
@@ -342,13 +342,12 @@ function DisabledProbe({source$}: {source$: Observable<string>}) {
   return null
 }
 
-test('the render-phase warm-up blip hits a cold source at most once per store entry', async () => {
-  // With `disabled: true` no live store subscription follows the warm-up probe, which
-  // makes the blip observable in isolation: subscribe during render, source teardown a
-  // tick later. Consumers like bifur's WebSocket connection must tolerate this
-  // momentary zero-subscriber gap — and react-rx must not repeat it on re-renders.
-  // The probe only runs when no initialValue is given; with one, the initial observable
-  // is never subscribed during render, so there is no blip at all.
+test('a disabled hook never probes the source: no render-phase blip at all', async () => {
+  // `disabled: true` skips both the live store subscription and the replacement warm-up, so
+  // consumers like bifur's WebSocket connection see zero subscriptions from disabled hooks.
+  // (Before initialValue became required, a disabled hook without one still ran the warm-up
+  // probe during render — the momentary subscribe/unsubscribe blip
+  // bifurClientConnection.test.ts guards against.)
   const events: string[] = []
   const source$ = new Observable<string>(() => {
     events.push('subscribe')
@@ -358,23 +357,26 @@ test('the render-phase warm-up blip hits a cold source at most once per store en
   })
 
   const {rerender} = render(<DisabledProbe source$={source$} />)
-  expect(events).toEqual(['subscribe'])
+  rerender(<DisabledProbe source$={source$} />)
+  rerender(<DisabledProbe source$={source$} />)
 
   await act(async () => {
     await tick()
   })
-  expect(events).toEqual(['subscribe', 'unsubscribe'])
-
-  // The WeakMap entry survives the blip, so re-renders do not probe again.
-  rerender(<DisabledProbe source$={source$} />)
-  rerender(<DisabledProbe source$={source$} />)
-  expect(events).toEqual(['subscribe', 'unsubscribe'])
+  expect(events).toEqual([])
 })
 
-test('a mounted hook bridges the warm-up gap: the source sees a single uninterrupted subscription', () => {
-  // The counterpart: with a live subscriber the probe's refCount blip is bridged by
-  // the asapScheduler grace, so the source is subscribed exactly once with no
-  // subscribe/unsubscribe churn in between.
+/** Kept at module scope so identity is stable across re-renders. */
+function ReplacementWarmUpProbe({observable}: {observable: Observable<string>}) {
+  useObservable(observable, 'initial')
+  return null
+}
+
+test('a replacement warm-up probes the source once, bridged into the commit subscription without churn', () => {
+  // The render-phase warm-up now only runs for replacement observables after an emission. With a
+  // live consumer the probe's refCount blip is bridged by the asapScheduler grace into the
+  // commit-time store subscription, so the source sees exactly one uninterrupted subscription
+  // with no subscribe/unsubscribe churn in between — and re-renders never probe again.
   const events: string[] = []
   const source$ = new Observable<string>((subscriber) => {
     events.push('subscribe')
@@ -383,13 +385,17 @@ test('a mounted hook bridges the warm-up gap: the source sees a single uninterru
       events.push('unsubscribe')
     }
   })
+  const first$ = new BehaviorSubject('first')
 
-  function Probe() {
-    useObservable(source$)
-    return null
-  }
-  render(<Probe />)
+  const {rerender} = render(<ReplacementWarmUpProbe observable={first$} />)
 
+  // first$ has emitted (sync BehaviorSubject emission on commit), so swapping identities warms
+  // the replacement during render.
+  rerender(<ReplacementWarmUpProbe observable={source$} />)
+  expect(events).toEqual(['subscribe'])
+
+  rerender(<ReplacementWarmUpProbe observable={source$} />)
+  rerender(<ReplacementWarmUpProbe observable={source$} />)
   expect(events).toEqual(['subscribe'])
 })
 
@@ -417,8 +423,8 @@ function SyncSelectionProbe({
   selection$: Observable<string | undefined>
   frames: SelectionFrame[]
 }) {
-  const name = useSyncObservable(selection$)
-  const releases = useSyncObservable(releases$)!
+  const name = useSyncObservable(selection$, undefined)
+  const releases = useSyncObservable(releases$, [])
   frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
   return null
 }
@@ -438,8 +444,8 @@ function DeferredSelectionProbe({
   selection$: Observable<string | undefined>
   frames: SelectionFrame[]
 }) {
-  const name = useSyncObservable(selection$)
-  const releases = useObservable(releases$)!
+  const name = useSyncObservable(selection$, undefined)
+  const releases = useObservable(releases$, [])
   frames.push({name, resolved: name !== undefined && releases.includes(name) ? name : undefined})
   return null
 }
@@ -495,8 +501,8 @@ function MixedSyncDeferredProbe({
   releases$: Observable<string[]>
   frames: CrossFrame[]
 }) {
-  const active = useSyncObservable(releases$)!
-  const all = useObservable(releases$)!
+  const active = useSyncObservable(releases$, [])
+  const all = useObservable(releases$, [])
   frames.push({active, all})
   return null
 }
@@ -508,8 +514,8 @@ function AllSyncProbe({
   releases$: Observable<string[]>
   frames: CrossFrame[]
 }) {
-  const active = useSyncObservable(releases$)!
-  const all = useSyncObservable(releases$)!
+  const active = useSyncObservable(releases$, [])
+  const all = useSyncObservable(releases$, [])
   frames.push({active, all})
   return null
 }

--- a/packages/react-rx/src/__tests__/sharedCache.test.tsx
+++ b/packages/react-rx/src/__tests__/sharedCache.test.tsx
@@ -11,10 +11,10 @@ test('useObservable and useSyncObservable share one source subscription for the 
     subscriber.next(subscribeCount++)
   })
 
-  const deferred = renderHook(() => useObservable(observable))
+  const deferred = renderHook(() => useObservable(observable, undefined))
   expect(deferred.result.current).toBe(0)
 
-  const sync = renderHook(() => useSyncObservable(observable))
+  const sync = renderHook(() => useSyncObservable(observable, undefined))
   expect(sync.result.current).toBe(0)
   expect(subscribeCount).toBe(1)
 
@@ -22,7 +22,7 @@ test('useObservable and useSyncObservable share one source subscription for the 
   sync.unmount()
   await Promise.resolve()
 
-  const remount = renderHook(() => useObservable(observable))
+  const remount = renderHook(() => useObservable(observable, undefined))
   expect(remount.result.current).toBe(1)
   remount.unmount()
 })

--- a/packages/react-rx/src/__tests__/strictmode.test.tsx
+++ b/packages/react-rx/src/__tests__/strictmode.test.tsx
@@ -25,7 +25,7 @@ describe.each(hooks)('$name', ({useHook}) => {
         // oxlint-disable-next-line react/todo -- compiler cannot yet lower ++ captured in lambdas
         mountCount++
       }, [])
-      const observedValue = useHook(observable)
+      const observedValue = useHook(observable, 0)
       returnedValues.push(observedValue)
       return <>{observedValue}</>
     }
@@ -35,7 +35,8 @@ describe.each(hooks)('$name', ({useHook}) => {
 
     // useObservable may schedule an Object.is bail-out deferred pass on mount
     // (useDeferredValue second arg is defined), so mount can produce more than two
-    // Strict Mode renders — all must still be the sync BehaviorSubject value.
+    // Strict Mode renders — all must still be 0 (the initialValue and the identical
+    // sync BehaviorSubject emission delivered on commit).
     expect(returnedValues.length).toBeGreaterThanOrEqual(2)
     expect(returnedValues.every((v) => v === 0)).toBe(true)
     const afterMount = returnedValues.length
@@ -66,7 +67,7 @@ describe.each(hooks)('$name', ({useHook}) => {
     })
 
     function ObservableComponent() {
-      useHook(observable)
+      useHook(observable, undefined)
       return null
     }
 
@@ -89,7 +90,7 @@ describe.each(hooks)('$name', ({useHook}) => {
 
     function ObservableComponent() {
       const memoObservable = useMemo(() => getObservable(), [])
-      useHook(memoObservable)
+      useHook(memoObservable, undefined)
       return null
     }
 

--- a/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.activity.test.tsx
@@ -13,11 +13,9 @@ import {useObservable} from '../useObservable'
  * When the boundary becomes visible again, subscriptions are re-created while
  * React state / the last rendered UI are preserved.
  *
- * When no `initialValue` is given, `useObservable` also eagerly probes the
- * observable during render to pick up synchronous emissions, so sync sources
- * can still populate the snapshot even when Activity has not yet mounted a
- * live subscription. With an `initialValue` there is no render-phase probe —
- * a hidden mount performs no subscription at all until it becomes visible.
+ * The observable is never subscribed during render for its first paint — a
+ * hidden mount performs no subscription at all until it becomes visible, and
+ * the (required) `initialValue` is what the hidden tree renders until then.
  *
  * While hidden, children can still re-render from new props (lower priority).
  * The WeakMap cache entry for a stable observable keeps `didEmit` / `snapshot`,
@@ -101,7 +99,7 @@ test('Activity hides and restores useObservable subscriptions the same way it do
   })
 
   function Child() {
-    return <div data-testid="value">{useObservable(observable)}</div>
+    return <div data-testid="value">{useObservable(observable, undefined)}</div>
   }
 
   render(
@@ -125,7 +123,7 @@ test('Activity hides and restores useObservable subscriptions the same way it do
   expect(screen.getByTestId('value').style.display).not.toBe('none')
 })
 
-test('sync observable (of/from) without initial value: hide keeps last value, show re-subscribes sync', async () => {
+test('sync observable (of/from) with an undefined initial value: hide keeps last value, show re-subscribes sync', async () => {
   let subscriptions = 0
   // Equivalent to `of('sync')` / `from(['sync'])` for the first emission: sync on subscribe.
   const observable = new Observable<string>((subscriber) => {
@@ -134,7 +132,7 @@ test('sync observable (of/from) without initial value: hide keeps last value, sh
   })
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
   render(
@@ -143,8 +141,7 @@ test('sync observable (of/from) without initial value: hide keeps last value, sh
     </ToggleActivity>,
   )
 
-  // Live subscription is active (eager probe + uSES share the same underlying subscription
-  // while refcount stays > 0 across the delayed reset window).
+  // The store subscription started on commit and delivered the sync emission right after mount.
   expect(subscriptions).toBe(1)
   expect(textOf('value')).toBe('sync')
 
@@ -216,7 +213,7 @@ test('async observable with initial value: shows initial until emission, keeps i
   expect(textOf('value')).toBe('fetched')
 })
 
-test('async observable without initial value: undefined until emission, then preserved across Activity toggles', async () => {
+test('async observable with an undefined initial value: undefined until emission, then preserved across Activity toggles', async () => {
   let resolve!: (value: string) => void
   const promise = new Promise<string>((r) => {
     resolve = r
@@ -224,7 +221,7 @@ test('async observable without initial value: undefined until emission, then pre
   const observable = defer(() => from(promise))
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
   render(
@@ -421,14 +418,18 @@ test('Activity initially hidden with async observable and initial value: never s
   expect(textOf('value')).toBe('fetched')
 })
 
-test('sync from() without initial value under initially-hidden Activity still renders the sync value', async () => {
-  const observable = from(['from-value'])
+test('sync from() with an undefined initial value under initially-hidden Activity: no subscription until visible', async () => {
+  let subscriptions = 0
+  const observable = defer(() => {
+    subscriptions++
+    return from(['from-value'])
+  })
 
   function Child() {
-    return <div data-testid="value">{String(useObservable(observable))}</div>
+    return <div data-testid="value">{String(useObservable(observable, undefined))}</div>
   }
 
-  render(
+  const {rerender} = render(
     <Activity mode="hidden">
       <Child />
     </Activity>,
@@ -438,8 +439,24 @@ test('sync from() without initial value under initially-hidden Activity still re
     await Promise.resolve()
   })
 
-  expect(textOf('value')).toBe('from-value')
+  // The observable is never subscribed during render, and a hidden Activity mounts no effects —
+  // even a synchronously emitting source stays untouched and the initialValue renders.
+  expect(subscriptions).toBe(0)
+  expect(textOf('value')).toBe('undefined')
   expect(screen.getByTestId('value').style.display).toBe('none')
+
+  rerender(
+    <Activity mode="visible">
+      <Child />
+    </Activity>,
+  )
+  await act(async () => {
+    await Promise.resolve()
+  })
+
+  // Becoming visible starts the live subscription; the sync emission replaces the initialValue.
+  expect(subscriptions).toBe(1)
+  expect(textOf('value')).toBe('from-value')
 })
 
 test('after async emission, hiding Activity then updating parent state: last emission survives when visible again (cache does not reset to initial)', async () => {

--- a/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.hydration.test.tsx
@@ -133,11 +133,11 @@ test('useObservable: sync-emitting observable + initialValue server-renders the 
   expect(screen.getByTestId('value').textContent).toBe('sync')
 })
 
-test('useObservable: async observable without initialValue server-renders nothing and hydrates cleanly', async () => {
+test('useObservable: async observable with an undefined initialValue server-renders nothing and hydrates cleanly', async () => {
   const observable = timer(60_000).pipe(map(() => 'later'))
 
   function App() {
-    const value = useObservable(observable)
+    const value = useObservable(observable, undefined)
     return <div data-testid="value">{value ?? ''}</div>
   }
 
@@ -149,43 +149,29 @@ test('useObservable: async observable without initialValue server-renders nothin
   expect(screen.getByTestId('value').textContent).toBe('')
 })
 
-test('useObservable: a NON-deterministic sync emission without an initialValue surfaces a hydration mismatch', async () => {
-  // Documentation test: without an initialValue the warm-up subscribes on both the server and
-  // the client, so per-subscription non-determinism shows up as a hydration mismatch.
-  // React 19 may report the mismatch via console.error and/or as an uncaught exception;
-  // either signal counts.
+test('useObservable: a NON-deterministic sync emission with an undefined initialValue hydrates cleanly (the server never subscribes)', async () => {
+  // Before initialValue became required, omitting it made the warm-up subscribe on both the
+  // server and the client, so per-subscription non-determinism showed up as a hydration
+  // mismatch. Now nothing subscribes during (server or first client) render: both paint the
+  // undefined initialValue, and the first subscription happens on the client after hydration.
   let n = 0
   const observable = new Observable<string>((subscriber) => {
     subscriber.next(`emit-${n++}`)
   })
 
   function App() {
-    return <div data-testid="value">{useObservable(observable)}</div>
+    return <div data-testid="value">{useObservable(observable, undefined)}</div>
   }
 
   const html = renderToString(<App />)
-  expect(html).toContain('emit-0')
+  expect(html).toBe('<div data-testid="value"></div>')
 
-  const uncaught: unknown[] = []
-  const onUnhandled = (event: ErrorEvent) => {
-    uncaught.push(event.error ?? event.message)
-    event.preventDefault()
-  }
-  window.addEventListener('error', onUnhandled)
-  try {
-    await hydrate(<App />, html)
-  } finally {
-    window.removeEventListener('error', onUnhandled)
-  }
-
-  const sawConsoleMismatch = hydrationErrors().length > 0
-  const sawUncaughtMismatch = uncaught.some((err) =>
-    /hydrat|did not match|Text content does not match/i.test(String(err)),
-  )
-  expect(sawConsoleMismatch || sawUncaughtMismatch).toBe(true)
+  await hydrate(<App />, html)
+  expect(hydrationErrors()).toEqual([])
+  expect(screen.getByTestId('value').textContent).toBe('emit-0')
 })
 
-test('useObservable: an initialValue avoids the warm-up, so a NON-deterministic sync emission hydrates cleanly', async () => {
+test('useObservable: with an initialValue a NON-deterministic sync emission hydrates cleanly too', async () => {
   let n = 0
   const observable = new Observable<string>((subscriber) => {
     subscriber.next(`emit-${n++}`)

--- a/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.leaks.test.tsx
@@ -1,6 +1,5 @@
 import {act, render} from '@testing-library/react'
-import {renderToString} from 'react-dom/server'
-import {defer, map, Observable, of, throwError, timer} from 'rxjs'
+import {defer, map, Observable, of, Subject, throwError, timer} from 'rxjs'
 import {expect, test} from 'vitest'
 
 import {useObservable} from '../useObservable'
@@ -10,18 +9,18 @@ import {useObservable} from '../useObservable'
  * record retains the last snapshot (or error) produced by the source. Records are only ever removed by
  * `finalize(() => cache.delete(observable))` in the piped observable.
  *
- * The eager subscription inside `useMemo` used to run BEFORE `cache.set(observable, entry)`. For sources
- * that terminate (complete or error) synchronously upon subscription, `finalize` fired during that eager
- * subscription — while the entry was not yet in the cache — so the delete was a no-op and the entry was
- * inserted right after, with nothing left to evict it. A later committed mount would re-trigger teardown
- * through its store subscription and clean the entry up, but that never happens for server renders,
- * disabled hooks (which still warm up via the eager subscribe, but never establish a store subscription),
- * or renders that throw before commit (synchronously erroring sources). In those cases the entry retained
- * the last snapshot/error for as long as the source observable object itself stayed alive, and a
- * poisoned entry replayed its stale error on later mounts instead of re-subscribing.
+ * The eager warm-up subscription inside `useMemo` used to run BEFORE `cache.set(observable, entry)`.
+ * For sources that terminate (complete or error) synchronously upon subscription, `finalize` fired
+ * during that eager subscription — while the entry was not yet in the cache — so the delete was a
+ * no-op and the entry was inserted right after, with nothing left to evict it. The entry then
+ * retained the last snapshot/error for as long as the source observable object itself stayed alive,
+ * and a poisoned entry replayed its stale error on later mounts instead of re-subscribing.
  *
- * Note: the eager warm-up subscription only runs for consumers without an `initialValue` — with one,
- * the source is never subscribed during render — so these scenarios omit the `initialValue`.
+ * Since `initialValue` became required, the warm-up only runs for replacement observables after the
+ * hook has received an emission — so these scenarios swap in the terminating source after a first
+ * emission. A synchronously erroring replacement still throws during render (before commit), which
+ * means no store subscription ever runs that could clean the entry up afterwards — the eviction
+ * during the warm-up itself is all there is.
  */
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -43,62 +42,47 @@ async function forceGC() {
   }
 }
 
-test('releases the last snapshot of a synchronously completing observable used by a disabled hook', async () => {
-  let snapshotRef: WeakRef<object> | undefined
+/** Kept at module scope so identity is stable across re-renders. */
+function UndefinedInitialProbe({observable}: {observable: Observable<unknown>}) {
+  useObservable(observable, undefined)
+  return null
+}
+
+test('releases the snapshots of a synchronously completing observable warmed up as a replacement', async () => {
+  const snapshotRefs: WeakRef<object>[] = []
   // Long-lived source, as if declared at module scope in an app. It emits a fresh object per
   // subscription and completes synchronously (like a replayed+completed cache observable would).
   const source = defer(() => {
     const snapshot = {payload: 'x'.repeat(1024)}
-    snapshotRef = new WeakRef(snapshot)
-    return of(snapshot)
+    snapshotRefs.push(new WeakRef(snapshot))
+    return of<unknown>(snapshot)
   })
+  const subject = new Subject<unknown>()
 
-  function ObservableComponent() {
-    useObservable(source, undefined, {disabled: true})
-    return null
-  }
+  const {rerender, unmount} = render(<UndefinedInitialProbe observable={subject} />)
+  // The replacement warm-up only engages once the hook has received an emission.
+  act(() => subject.next('emitted'))
 
-  const {unmount} = render(<ObservableComponent />)
+  // The swap warms `source` up during render; it completes synchronously during that eager
+  // subscription, so `finalize` must find the entry in the cache and evict it right away.
+  rerender(<UndefinedInitialProbe observable={source} />)
   unmount()
 
   await forceGC()
 
-  // While disabled, the hook (given no initialValue) still performs its eager render-phase warm-up
-  // subscription (disabled only pauses the live store subscription), but nothing re-triggers teardown
-  // after that — so the entry created during render must already have been evicted, releasing the
-  // snapshot.
-  expect(snapshotRef!.deref()).toBeUndefined()
-  // Keep the source — the WeakMap key — strongly reachable across the GC above, so the snapshot can
-  // only have been released through eviction, not by the key getting collected.
-  expect(source).toBeInstanceOf(Observable)
-})
-
-test('releases the last snapshot of a synchronously completing observable after server-side rendering', async () => {
-  let snapshotRef: WeakRef<object> | undefined
-  const source = defer(() => {
-    const snapshot = {payload: 'x'.repeat(1024)}
-    snapshotRef = new WeakRef(snapshot)
-    return of(snapshot)
-  })
-
-  function ObservableComponent() {
-    useObservable(source)
-    return null
+  expect(snapshotRefs.length).toBeGreaterThan(0)
+  for (const ref of snapshotRefs) {
+    expect(ref.deref()).toBeUndefined()
   }
-
-  // On the server there is no commit phase and no store subscription, only the eager subscription made
-  // during render when no initialValue is given — the cache entry must not outlive it, or every unique
-  // observable rendered by a long-lived server process would keep its last snapshot alive. (With an
-  // initialValue the source is never subscribed during server rendering at all.)
-  renderToString(<ObservableComponent />)
-
-  await forceGC()
-
-  expect(snapshotRef!.deref()).toBeUndefined()
-  // Keep the source — the WeakMap key — strongly reachable across the GC above, so the snapshot can
-  // only have been released through eviction, not by the key getting collected.
+  // Keep the source — the WeakMap key — strongly reachable across the GC above, so the snapshots
+  // can only have been released through eviction, not by the key getting collected.
   expect(source).toBeInstanceOf(Observable)
 })
+
+/** Kept at module scope so identity is stable across re-renders. */
+function RenderedValueProbe({observable}: {observable: Observable<string>}) {
+  return <>{useObservable(observable, 'initial')}</>
+}
 
 test('re-subscribes a synchronously erroring observable on a later mount instead of replaying a stale error', async () => {
   let shouldFail = true
@@ -107,17 +91,18 @@ test('re-subscribes a synchronously erroring observable on a later mount instead
     subscriptions++
     return shouldFail ? throwError(() => new Error('transient error')) : of('recovered')
   })
+  const subject = new Subject<string>()
 
-  function ObservableComponent() {
-    return <>{useObservable(source)}</>
-  }
-
-  // First mount (no initialValue, so the warm-up runs): the source errors synchronously during the
-  // eager render-phase subscription, so the render throws before commit and no store subscription
-  // ever runs that could clean up the cache entry created for the errored source. The source keeps
-  // failing for the whole mount, which keeps the test agnostic to how many render attempts React
-  // makes before surfacing the error.
-  expect(() => render(<ObservableComponent />)).toThrow('transient error')
+  // Swap to the erroring source after an emission: the replacement warm-up subscribes it during
+  // render, captures the error, and the same render throws it from `getSnapshot` — before commit,
+  // so no store subscription ever runs that could clean up the cache entry created for the errored
+  // source. The source keeps failing for the whole swap, which keeps the test agnostic to how many
+  // render attempts React makes before surfacing the error.
+  const first = render(<RenderedValueProbe observable={subject} />)
+  act(() => subject.next('emitted'))
+  expect(() => first.rerender(<RenderedValueProbe observable={source} />)).toThrow(
+    'transient error',
+  )
   const failedSubscriptions = subscriptions
   expect(failedSubscriptions).toBeGreaterThan(0)
 
@@ -127,7 +112,7 @@ test('re-subscribes a synchronously erroring observable on a later mount instead
 
   // A later mount in the same runtime must re-subscribe the source (which has recovered) instead of
   // a leftover cache entry replaying the stale error and turning the transient failure permanent.
-  const {container} = render(<ObservableComponent />)
+  const {container} = render(<RenderedValueProbe observable={source} />)
   expect(subscriptions).toBeGreaterThan(failedSubscriptions)
   expect(container.textContent).toBe('recovered')
 })
@@ -149,7 +134,7 @@ test('releases the last snapshot of an asynchronously completing observable afte
   )
 
   function ObservableComponent() {
-    useObservable(source)
+    useObservable(source, undefined)
     return null
   }
 

--- a/packages/react-rx/src/__tests__/useObservable.test-d.ts
+++ b/packages/react-rx/src/__tests__/useObservable.test-d.ts
@@ -3,13 +3,17 @@ import {expectTypeOf, test} from 'vitest'
 
 import {useObservable} from '../useObservable'
 
-test('useObservable with no initial value can be undefined', () => {
+test('useObservable requires an initialValue', () => {
   const observable = of('foo')
 
-  expectTypeOf(useObservable(observable)).toEqualTypeOf<string | undefined>()
+  //@ts-expect-error - initialValue is required; use useObservablePromise when there is none
+  useObservable(observable)
+})
 
-  //@ts-expect-error - because initial value is not given, we can't guarantee the observable emits a sync value, so it could be undefined
-  expectTypeOf(useObservable(observable)).toEqualTypeOf<string>()
+test('an explicit undefined initialValue is valid and widens the return type', () => {
+  const observable = of('foo')
+
+  expectTypeOf(useObservable(observable, undefined)).toEqualTypeOf<string | undefined>()
 })
 
 test('return type of useObservable with initial value is not undefined', () => {
@@ -24,4 +28,12 @@ test('useObservable with initial value if a different type returns a union of th
   expectTypeOf(useObservable(observable, 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useObservable(observable, () => 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useObservable(observable, 'foo')).toEqualTypeOf<string>()
+})
+
+const double = (n: number) => n * 2
+
+test('a function initial value is provided through an initializer, like useState', () => {
+  const observable = of((n: number) => n + 1)
+
+  expectTypeOf(useObservable(observable, () => double)).toEqualTypeOf<(n: number) => number>()
 })

--- a/packages/react-rx/src/__tests__/useObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useObservable.test.tsx
@@ -31,7 +31,7 @@ test('should subscribe immediately on component mount and unsubscribe on compone
 
   expect(subscribed).toBe(false)
 
-  const {unmount} = renderHook(() => useObservable(observable))
+  const {unmount} = renderHook(() => useObservable(observable, undefined))
   expect(subscribed).toBe(true)
 
   unmount()
@@ -47,14 +47,14 @@ test('should only subscribe once when given same observable on re-renders', asyn
 
   expect(subscriptionCount).toBe(0)
 
-  const {unmount, rerender} = renderHook(() => useObservable(observable))
+  const {unmount, rerender} = renderHook(() => useObservable(observable, undefined))
   expect(subscriptionCount).toBe(1)
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
   await Promise.resolve()
 
-  renderHook(() => useObservable(observable))
+  renderHook(() => useObservable(observable, undefined))
   expect(subscriptionCount).toBe(2)
 })
 
@@ -71,41 +71,18 @@ test('should not return undefined during render if initial value is given', () =
   expect(returnedValues).toEqual(expect.arrayContaining(['initial value']))
 })
 
-test('should not return undefined during render if observable is sync', () => {
-  const observable = of('initial value')
-
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    const observedValue = useObservable(observable)
-    returnedValues.push(observedValue)
-    return <>{observedValue}</>
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues).toEqual(expect.arrayContaining(['initial value']))
-})
-
-test('should return undefined during first render if observable is async', () => {
-  const observable = scheduled('async value', asyncScheduler)
-
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    const observedValue = useObservable(observable)
-    returnedValues.push(observedValue)
-    return <>{observedValue}</>
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues).toEqual(expect.arrayContaining([undefined]))
-})
-
-test('should have sync values from an observable as initial value', () => {
+test('a sync emission replaces an explicit undefined initialValue right after mount', () => {
+  // The observable is never subscribed during render: the first render shows the (undefined)
+  // initialValue, and the store subscription on commit delivers the sync emission before
+  // renderHook returns.
   const observable = of('something sync')
-  const {result} = renderHook(() => useObservable(observable))
+  const {result} = renderHook(() => useObservable(observable, undefined))
   expect(result.current).toBe('something sync')
 })
 
 test('should have undefined as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useObservable(scheduled('something async', asyncScheduler)),
+    useObservable(scheduled('something async', asyncScheduler), undefined),
   )
   expect(result.current).toBeUndefined()
   unmount()
@@ -141,15 +118,15 @@ test('should share the observable between each concurrent subscribing hook', asy
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
   })
-  const firstHook = renderHook(() => useObservable(observable))
+  const firstHook = renderHook(() => useObservable(observable, undefined))
   expect(firstHook.result.current).toBe(0)
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useObservable(observable, undefined))
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
   await Promise.resolve()
 
-  const thirdHook = renderHook(() => useObservable(observable))
+  const thirdHook = renderHook(() => useObservable(observable, undefined))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
@@ -198,7 +175,7 @@ test('should restart any completed observable on mount', async () => {
   firstHook.unmount()
   await Promise.resolve()
 
-  const secondHook = renderHook(() => useObservable(observable))
+  const secondHook = renderHook(() => useObservable(observable, undefined))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
@@ -210,7 +187,7 @@ test('should restart any completed observable on mount', async () => {
 
 test('should update with values from observables', () => {
   const values$ = new Subject<string>()
-  const {result, unmount} = renderHook(() => useObservable(values$))
+  const {result, unmount} = renderHook(() => useObservable(values$, undefined))
 
   expect(result.current).toBe(undefined)
 
@@ -279,13 +256,13 @@ test('falls back to the live value when the observable identity changes (deferra
   unmount()
 })
 
-test('identity change without an initialValue renders the new observable synchronous emission immediately (warm-up)', () => {
+test('identity change with an undefined initialValue renders the new observable synchronous emission immediately (warm-up)', () => {
   const subjectA = new BehaviorSubject('value for a')
   const subjectB = new BehaviorSubject('initial for b')
   const renderTimeline: (string | undefined)[] = []
 
   function ObservableComponent({observable}: {observable: BehaviorSubject<string>}) {
-    renderTimeline.push(useObservable(observable))
+    renderTimeline.push(useObservable(observable, undefined))
     return null
   }
   const {rerender, unmount} = render(<ObservableComponent observable={subjectA} />)
@@ -294,10 +271,12 @@ test('identity change without an initialValue renders the new observable synchro
   const timelineLengthBeforeSwitch = renderTimeline.length
   rerender(<ObservableComponent observable={subjectB} />)
 
-  // Without an initialValue the warm-up runs during the switch render, so the very first
-  // render after the identity change already shows subjectB's synchronous emission.
+  // After the first emission, replacement observables are warmed up during the switch render, so
+  // the very first render after the identity change already shows subjectB's synchronous
+  // emission — never the undefined initialValue.
   expect(renderTimeline[timelineLengthBeforeSwitch]).toBe('initial for b')
   expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain('value for a')
+  expect(renderTimeline.slice(timelineLengthBeforeSwitch)).not.toContain(undefined)
 
   unmount()
 })
@@ -452,23 +431,9 @@ test('should return the actual value when the hook is disabled and then re-enabl
   unmount()
 })
 
-test('sync emission wins over an omitted initialValue on the first render (warm-up)', () => {
-  // Without an initialValue the observable is briefly subscribed during render, so the sync
-  // emission is the very first rendered value — never undefined.
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    returnedValues.push(useObservable(of('sync')))
-    return null
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues[0]).toBe('sync')
-  expect(returnedValues.every((v) => v === 'sync')).toBe(true)
-})
-
-test('an initialValue skips the render-phase warm-up: the initialValue paints first, the sync emission follows after mount', () => {
-  // With an initialValue there is nothing to warm up for — the source is first subscribed by
-  // the live store subscription on commit, keeping subscribe-time side effects out of the
-  // render phase.
+test('the observable is never subscribed during render: the initialValue paints first, the sync emission follows after mount', () => {
+  // There is nothing to warm up on mount — the source is first subscribed by the live store
+  // subscription on commit, keeping subscribe-time side effects out of the render phase.
   let subscriptions = 0
   const source = defer(() => {
     subscriptions++
@@ -488,10 +453,9 @@ test('an initialValue skips the render-phase warm-up: the initialValue paints fi
   expect(subscriptions).toBe(1)
 })
 
-test('disabled with an initialValue never subscribes the source (zero subscriptions)', () => {
-  // Without an initialValue, `disabled` still runs the warm-up subscription; with one, there
-  // is no render-phase warm-up and `disabled` pauses the store subscription — so nothing ever
-  // subscribes the source.
+test('disabled never subscribes the source (zero subscriptions)', () => {
+  // There is no render-phase warm-up on mount, and `disabled` pauses the store subscription —
+  // so nothing ever subscribes the source.
   let subscriptions = 0
   const source = defer(() => {
     subscriptions++
@@ -503,31 +467,41 @@ test('disabled with an initialValue never subscribes the source (zero subscripti
   unmount()
 })
 
-test('a consumer without an initialValue warms up a shared entry created by an initialValue consumer', () => {
-  // `WithInitial` renders first and creates the shared cache entry without warming it up;
-  // `WithoutInitial` relies on sync emissions being available on its first render, so the
-  // cache hit warms the entry up on its behalf.
-  const source = of('sync')
-  const withInitial: unknown[] = []
-  const withoutInitial: unknown[] = []
-  function WithInitial() {
-    withInitial.push(useObservable(source, 'initial'))
+test('a consumer that swaps observables after an emission warms up a shared entry created un-warmed by another consumer', () => {
+  // `DisabledCreator` creates the shared cache entry for `source` without warming it up (a
+  // disabled hook performs no subscriptions). `Swapper` has already received an emission from
+  // `subject`, so when it swaps to `source` its render must show the synchronous emission
+  // immediately — the cache hit warms the shared entry up on its behalf.
+  const subject = new BehaviorSubject('first value')
+  const source = new BehaviorSubject('sync')
+  const swapper: unknown[] = []
+  function DisabledCreator() {
+    useObservable(source, 'creator initial', {disabled: true})
     return null
   }
-  function WithoutInitial() {
-    withoutInitial.push(useObservable(source))
+  function Swapper({observable}: {observable: Observable<string>}) {
+    swapper.push(useObservable(observable, 'swapper initial'))
     return null
   }
-  render(
+  const {rerender} = render(
     <>
-      <WithInitial />
-      <WithoutInitial />
+      <DisabledCreator />
+      <Swapper observable={subject} />
     </>,
   )
-  expect(withInitial[0]).toBe('initial')
-  expect(withoutInitial[0]).toBe('sync')
-  // Once the entry is warm, the initialValue consumer reads the emitted snapshot too.
-  expect(withInitial.at(-1)).toBe('sync')
+  expect(swapper.at(-1)).toBe('first value')
+
+  const swapIndex = swapper.length
+  rerender(
+    <>
+      <DisabledCreator />
+      <Swapper observable={source} />
+    </>,
+  )
+  // The swap render reads 'sync' right away — the un-warmed shared entry was warmed during
+  // render, so the consumer converges instead of rendering its initialValue first.
+  expect(swapper[swapIndex]).toBe('sync')
+  expect(swapper.slice(swapIndex)).not.toContain('swapper initial')
 })
 
 test('remount shows the cached snapshot immediately, never the initialValue', async () => {
@@ -662,34 +636,29 @@ test('SSR with an async observable renders the resolved initialValue', () => {
   expect(renderToString(<ObservableComponent />)).toBe('initial value')
 })
 
-test('SSR without an initialValue no longer throws', () => {
-  // Contrast with useSyncObservable, which still throws without getServerSnapshot.
-  expect(renderToString(<SSRSyncEmit />)).toBe('sync')
-  // Empty output matches the client's first paint (undefined).
-  expect(renderToString(<SSRAsyncNoInitial />)).toBe('')
-})
-
-function SSRSyncEmit() {
-  return <>{useObservable(of('sync'))}</>
-}
-
-function SSRAsyncNoInitial() {
-  return <>{useObservable(scheduled('async', asyncScheduler))}</>
-}
-
-test('SSR surfaces synchronous observable errors when no initialValue is given', () => {
-  // Without an initialValue the warm-up captures the error during the server render, and the
-  // snapshot-based getServerSnapshot fails the server render with the observable's error.
-  const observable = throwError(() => new Error('boom'))
-  function ObservableComponent() {
-    return <>{useObservable(observable)}</>
+test('SSR with an explicit undefined initialValue renders nothing and never subscribes', () => {
+  // The server never subscribes the observable — even a synchronous emission is not picked up.
+  // Empty output matches the client's first paint (the undefined initialValue).
+  let subscriptions = 0
+  const source = defer(() => {
+    subscriptions++
+    return of('sync')
+  })
+  function SSRSyncEmit() {
+    return <>{useObservable(source, undefined)}</>
   }
 
-  expect(() => renderToString(<ObservableComponent />)).toThrow('boom')
+  expect(renderToString(<SSRSyncEmit />)).toBe('')
+  expect(subscriptions).toBe(0)
+  expect(renderToString(<SSRAsyncUndefined />)).toBe('')
 })
 
-test('SSR with an initialValue renders it and leaves a synchronous error to the client subscription', () => {
-  // With an initialValue there is no render-phase warm-up, so nothing can throw on the
+function SSRAsyncUndefined() {
+  return <>{useObservable(scheduled('async', asyncScheduler), undefined)}</>
+}
+
+test('SSR renders the initialValue and leaves a synchronous error to the client subscription', () => {
+  // The observable is never subscribed during server rendering, so nothing can throw on the
   // server: it paints the initialValue, and the error surfaces on the client once the store
   // subscription starts after mount.
   const observable = throwError(() => new Error('boom'))

--- a/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.activity.test.tsx
@@ -13,10 +13,9 @@ import {useSyncObservable} from '../useSyncObservable'
  *
  * - `<Activity mode="hidden">` tears down the `useSyncExternalStore` subscription and
  *   re-creates it on reveal, while React state / the last rendered UI are preserved.
- * - Without an `initialValue`, the render-phase warm-up probe still seeds synchronous
- *   emissions into the WeakMap cache even when Activity has not mounted a live
- *   subscription yet. With an `initialValue` there is no probe — a hidden mount performs
- *   no subscription at all until it becomes visible.
+ * - The observable is never subscribed during render for its first paint — a hidden mount
+ *   performs no subscription at all until it becomes visible, and the (required)
+ *   `initialValue` is what the hidden tree renders until then.
  * - The cache entry keeps `didEmit` / `snapshot` across hidden re-renders, so revealed
  *   panes resume from the last emission instead of the `initialValue`.
  */
@@ -59,7 +58,7 @@ test('Activity hides and restores useSyncObservable subscriptions the same way i
   })
 
   function Child() {
-    return <div data-testid="value">{useSyncObservable(observable)}</div>
+    return <div data-testid="value">{useSyncObservable(observable, undefined)}</div>
   }
 
   render(

--- a/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test-d.ts
@@ -3,13 +3,17 @@ import {expectTypeOf, test} from 'vitest'
 
 import {useSyncObservable} from '../useSyncObservable'
 
-test('useSyncObservable with no initial value can be undefined', () => {
+test('useSyncObservable requires an initialValue', () => {
   const observable = of('foo')
 
-  expectTypeOf(useSyncObservable(observable)).toEqualTypeOf<string | undefined>()
+  //@ts-expect-error - initialValue is required; use useObservablePromise when there is none
+  useSyncObservable(observable)
+})
 
-  //@ts-expect-error - because initial value is not given, we can't guarantee the observable emits a sync value, so it could be undefined
-  expectTypeOf(useSyncObservable(observable)).toEqualTypeOf<string>()
+test('an explicit undefined initialValue is valid and widens the return type', () => {
+  const observable = of('foo')
+
+  expectTypeOf(useSyncObservable(observable, undefined)).toEqualTypeOf<string | undefined>()
 })
 
 test('return type of useSyncObservable with initial value is not undefined', () => {
@@ -24,4 +28,12 @@ test('useSyncObservable with initial value if a different type returns a union o
   expectTypeOf(useSyncObservable(observable, 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useSyncObservable(observable, () => 1)).toEqualTypeOf<string | number>()
   expectTypeOf(useSyncObservable(observable, 'foo')).toEqualTypeOf<string>()
+})
+
+const double = (n: number) => n * 2
+
+test('a function initial value is provided through an initializer, like useState', () => {
+  const observable = of((n: number) => n + 1)
+
+  expectTypeOf(useSyncObservable(observable, () => double)).toEqualTypeOf<(n: number) => number>()
 })

--- a/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
+++ b/packages/react-rx/src/__tests__/useSyncObservable.test.tsx
@@ -29,7 +29,7 @@ test('should subscribe immediately on component mount and unsubscribe on compone
 
   expect(subscribed).toBe(false)
 
-  const {unmount} = renderHook(() => useSyncObservable(observable))
+  const {unmount} = renderHook(() => useSyncObservable(observable, undefined))
   expect(subscribed).toBe(true)
 
   unmount()
@@ -45,14 +45,14 @@ test('should only subscribe once when given same observable on re-renders', asyn
 
   expect(subscriptionCount).toBe(0)
 
-  const {unmount, rerender} = renderHook(() => useSyncObservable(observable))
+  const {unmount, rerender} = renderHook(() => useSyncObservable(observable, undefined))
   expect(subscriptionCount).toBe(1)
   rerender()
   expect(subscriptionCount).toBe(1)
   unmount()
   await Promise.resolve()
 
-  renderHook(() => useSyncObservable(observable))
+  renderHook(() => useSyncObservable(observable, undefined))
   expect(subscriptionCount).toBe(2)
 })
 
@@ -69,42 +69,18 @@ test('should not return undefined during render if initial value is given', () =
   expect(returnedValues).toEqual(expect.arrayContaining(['initial value']))
 })
 
-test('should not return undefined during render if observable is sync', () => {
-  const observable = of('initial value')
-
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    const observedValue = useSyncObservable(observable)
-    returnedValues.push(observedValue)
-    return <>{observedValue}</>
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues).toEqual(expect.arrayContaining(['initial value']))
-})
-
-test('should return undefined during first render if observable is async', () => {
-  const observable = scheduled('async value', asyncScheduler)
-
-  const returnedValues: unknown[] = []
-  function ObservableComponent() {
-    const observedValue = useSyncObservable(observable)
-    returnedValues.push(observedValue)
-    return <>{observedValue}</>
-  }
-  render(<ObservableComponent />)
-  expect(returnedValues).toEqual(expect.arrayContaining([undefined]))
-})
-
-test('should have sync values from an observable as initial value', () => {
+test('a sync emission replaces an explicit undefined initialValue right after mount', () => {
+  // The observable is never subscribed during render: the first render shows the (undefined)
+  // initialValue, and the store subscription on commit delivers the sync emission before
+  // renderHook returns.
   const observable = of('something sync')
-  const {result} = renderHook(() => useSyncObservable(observable))
+  const {result} = renderHook(() => useSyncObservable(observable, undefined))
   expect(result.current).toBe('something sync')
 })
 
-test('an initialValue skips the render-phase warm-up: the initialValue paints first, the sync emission follows after mount', () => {
-  // With an initialValue there is nothing to warm up for — the source is first subscribed by
-  // the live store subscription on commit, keeping subscribe-time side effects out of the
-  // render phase.
+test('the observable is never subscribed during render: the initialValue paints first, the sync emission follows after mount', () => {
+  // There is nothing to warm up on mount — the source is first subscribed by the live store
+  // subscription on commit, keeping subscribe-time side effects out of the render phase.
   let subscriptions = 0
   const source = defer(() => {
     subscriptions++
@@ -124,10 +100,9 @@ test('an initialValue skips the render-phase warm-up: the initialValue paints fi
   expect(subscriptions).toBe(1)
 })
 
-test('disabled with an initialValue never subscribes the source (zero subscriptions)', () => {
-  // Without an initialValue, `disabled` still runs the warm-up subscription; with one, there
-  // is no render-phase warm-up and `disabled` pauses the store subscription — so nothing ever
-  // subscribes the source.
+test('disabled never subscribes the source (zero subscriptions)', () => {
+  // There is no render-phase warm-up on mount, and `disabled` pauses the store subscription —
+  // so nothing ever subscribes the source.
   let subscriptions = 0
   const source = defer(() => {
     subscriptions++
@@ -141,7 +116,7 @@ test('disabled with an initialValue never subscribes the source (zero subscripti
 
 test('should have undefined as initial value from delayed observables', () => {
   const {result, unmount} = renderHook(() =>
-    useSyncObservable(scheduled('something async', asyncScheduler)),
+    useSyncObservable(scheduled('something async', asyncScheduler), undefined),
   )
   expect(result.current).toBeUndefined()
   unmount()
@@ -177,15 +152,15 @@ test('should share the observable between each concurrent subscribing hook', asy
   const observable = new Observable<number>((subscriber) => {
     subscriber.next(subscribeCount++)
   })
-  const firstHook = renderHook(() => useSyncObservable(observable))
+  const firstHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(firstHook.result.current).toBe(0)
-  const secondHook = renderHook(() => useSyncObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(secondHook.result.current).toBe(0)
   firstHook.unmount()
   secondHook.unmount()
   await Promise.resolve()
 
-  const thirdHook = renderHook(() => useSyncObservable(observable))
+  const thirdHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(thirdHook.result.current).toBe(1)
   thirdHook.unmount()
 })
@@ -234,7 +209,7 @@ test('should restart any completed observable on mount', async () => {
   firstHook.unmount()
   await Promise.resolve()
 
-  const secondHook = renderHook(() => useSyncObservable(observable))
+  const secondHook = renderHook(() => useSyncObservable(observable, undefined))
   expect(secondHook.result.current).toBe(undefined)
   expect(subscribeCount).toBe(2)
   expect(unsubscribeCount).toBe(1)
@@ -246,7 +221,7 @@ test('should restart any completed observable on mount', async () => {
 
 test('should update with values from observables', () => {
   const values$ = new Subject<string>()
-  const {result, unmount} = renderHook(() => useSyncObservable(values$))
+  const {result, unmount} = renderHook(() => useSyncObservable(values$, undefined))
 
   expect(result.current).toBe(undefined)
 
@@ -347,22 +322,9 @@ test('should support SSR if an initial value is given', () => {
   expect(renderToString(<ObservableComponent />)).toBe('initial value')
 })
 
-test('should throw during SSR if no initial value is defined', () => {
-  const observable = scheduled('async value', asyncScheduler)
-  function ObservableComponent() {
-    const observedValue = useSyncObservable(observable)
-    return <>{observedValue}</>
-  }
-
-  expect(() => renderToString(<ObservableComponent />)).toThrowErrorMatchingInlineSnapshot(
-    `[Error: Missing getServerSnapshot, which is required for server-rendered content. Will revert to client rendering.]`,
-  )
-})
-
 test('SSR renders the initialValue even when the observable emits synchronously', () => {
-  // Neither hook subscribes during render when an initialValue is given, so both paint the
-  // initialValue on the server. The remaining contrast with `useObservable` is the strict v4
-  // contract: `useSyncObservable` throws without an initialValue, `useObservable` does not.
+  // Neither hook subscribes during render, so both paint the resolved initialValue on the
+  // server (and both throw when it is omitted — see requiredInitialValue.test.tsx).
   const observable = of('sync')
   function ObservableComponent() {
     const observedValue = useSyncObservable(observable, 'initial')

--- a/packages/react-rx/src/cache.ts
+++ b/packages/react-rx/src/cache.ts
@@ -33,33 +33,25 @@ export interface WarmUpTracker {
 /**
  * Decide whether a hook must warm up `observable` during render.
  *
- * Without an `initialValue` the answer is always yes: synchronous emissions (e.g. from
- * `startWith`) must be renderable from the very first render — even while `disabled`, which only
- * pauses the live store subscription.
- *
- * With an `initialValue` the warm-up is only needed for a replacement observable after the entry
- * the hook last subscribed has emitted. From that point on, a store update forces a re-render, and
- * if that render swaps in a fresh identity whose rendered snapshot (the `initialValue`) differs
- * from what the commit-time subscription delivers, `useSyncExternalStore` forces another render —
- * consumers that rebuild the observable on every render would loop forever. Warming the
- * replacement makes its rendered snapshot match the subscription and the loop converges.
+ * The warm-up is only needed for a replacement observable after the entry the hook last
+ * subscribed has emitted. From that point on, a store update forces a re-render, and if that
+ * render swaps in a fresh identity whose rendered snapshot (the `initialValue`) differs from what
+ * the commit-time subscription delivers, `useSyncExternalStore` forces another render — consumers
+ * that rebuild the observable on every render would loop forever. Warming the replacement makes
+ * its rendered snapshot match the subscription and the loop converges.
  *
  * Before the first emission no store update can force a re-render, so identity churn from Strict
  * Mode double renders or parent updates stays subscription-free. The same holds for the entire
- * time a hook is `disabled` — without a live store subscription there is nothing to loop — so with
- * an `initialValue`, `disabled: true` performs no subscriptions at all, memoized or not.
+ * time a hook is `disabled` — without a live store subscription there is nothing to loop — so a
+ * `disabled` hook performs no subscriptions at all, memoized or not.
  *
  * @internal
  */
 export function needsWarmUp(
   tracker: WarmUpTracker,
   observable: Observable<any>,
-  hasInitialValue: boolean,
   disabled: boolean,
 ): boolean {
-  if (!hasInitialValue) {
-    return true
-  }
   if (disabled) {
     return false
   }
@@ -90,10 +82,10 @@ export function trackSubscribed(
  * entry and source subscription for the same observable.
  *
  * With `shouldWarmUp: true` the entry is also warmed up so that a synchronous emission (e.g. from
- * `startWith`) is available on the caller's first render of it. The hooks request this for every
- * observable except their initial one when an `initialValue` is provided — in that case there is
- * already a value to render, so the source is not subscribed during render at all and the live
- * store subscription picks up emissions once the hook commits.
+ * `startWith`) is available on the caller's first render of it. The hooks only request this for
+ * replacement observables after they have received an emission (see `needsWarmUp`) — otherwise
+ * there is always an `initialValue` to render, so the source is not subscribed during render at
+ * all and the live store subscription picks up emissions once the hook commits.
  *
  * @internal
  */
@@ -156,8 +148,7 @@ export function getOrCreateStore<ObservableType extends Observable<any>>(
   // on remount instead of re-subscribing the source.
   cache.set(observable, entry)
 
-  // The warm-up runs even when `disabled` is true — `disabled` only pauses the hooks' live store
-  // subscription. When it is skipped (the hooks' initial observable with an `initialValue`),
+  // When the warm-up is skipped (everything except replacement observables after an emission),
   // subscribe-time side effects stay out of the render phase; the source is first subscribed when
   // the store subscription starts on commit.
   if (shouldWarmUp) {

--- a/packages/react-rx/src/types.ts
+++ b/packages/react-rx/src/types.ts
@@ -2,9 +2,9 @@
 export interface UseObservableOptions {
   /**
    * Pause the active store subscription. While `true`, later emissions do not update the component
-   * and the last received value (or `initialValue`) is returned. The render-phase warm-up
-   * subscription still runs when no `initialValue` is given — pair an `initialValue` with
-   * `disabled: true` and the hook performs no subscriptions at all.
+   * and the last received value (or the resolved `initialValue`) is returned. A disabled hook
+   * performs no subscriptions at all — the render-phase warm-up for replacement observables is
+   * skipped too.
    */
   disabled?: boolean
 }

--- a/packages/react-rx/src/useObservable.ts
+++ b/packages/react-rx/src/useObservable.ts
@@ -3,7 +3,7 @@ import type {Observable, ObservedValueOf} from 'rxjs'
 
 import {getOrCreateStore, needsWarmUp, trackSubscribed, type WarmUpTracker} from './cache'
 import type {UseObservableOptions} from './types'
-import {EMPTY_OBJECT} from './utils'
+import {EMPTY_OBJECT, missingInitialValueError, UNSET_INITIAL_VALUE} from './utils'
 
 /**
  * Subscribe to an observable and return its latest value, with store updates deferred via
@@ -14,16 +14,22 @@ import {EMPTY_OBJECT} from './utils'
  * Suspense fallback. Mounts, remounts, and `<Activity>` reveals still render the current snapshot
  * synchronously (no initial-value flash once a value has been emitted).
  *
- * When no `initialValue` is given, the observable is briefly subscribed during render so a
- * synchronous emission (e.g. from `startWith`) can be returned from the very first render. With an
- * `initialValue` the observable is not subscribed during render: the `initialValue` renders first
- * and the live subscription starts on commit, keeping subscribe-time side effects out of the
- * render phase — a synchronous emission then replaces the `initialValue` right after mount. Only
- * once the hook has received an emission are replacement observables (a changed identity on a
- * later render) warmed up during render again: rendering their synchronous emission immediately is
- * what lets consumers that rebuild the observable on every render settle instead of re-rendering
- * forever. Identity churn before the first emission (e.g. Strict Mode double renders or parent
- * updates) and any identity churn while `disabled` stay subscription-free.
+ * `initialValue` is required: it is what renders until the observable emits. Every value is a
+ * valid initial value, `undefined` included — pass it explicitly; omitting the argument throws
+ * during render. Functions act as initializers, exactly like `useState`: pass `() => value` to
+ * compute the initial value lazily, and an initializer returning the function when the initial
+ * value should be a function itself. When there is no meaningful initial value, or you want to
+ * show fallback UI while the observable is "loading", reach for {@link useObservablePromise} with
+ * `use()` and Suspense instead.
+ *
+ * The observable is not subscribed during render: the `initialValue` renders first and the live
+ * subscription starts on commit, keeping subscribe-time side effects out of the render phase — a
+ * synchronous emission then replaces the `initialValue` right after mount. Only once the hook has
+ * received an emission are replacement observables (a changed identity on a later render) warmed
+ * up during render: rendering their synchronous emission immediately is what lets consumers that
+ * rebuild the observable on every render settle instead of re-rendering forever. Identity churn
+ * before the first emission (e.g. Strict Mode double renders or parent updates) and any identity
+ * churn while `disabled` stay subscription-free.
  *
  * The deferral is identity-coherent: unlike a bare `useDeferredValue(useObservable(...))`, the
  * observable identity and its value are deferred as one snapshot, and when the observable identity
@@ -31,10 +37,9 @@ import {EMPTY_OBJECT} from './utils'
  * value — typically the new observable's synchronous emission or the `initialValue` — so the
  * previous identity's value never renders under the new one.
  *
- * On the server this hook renders exactly what the client's first paint will show (the resolved
- * `initialValue` when one is provided, else a synchronous emission when there is one, else nothing)
- * and never throws for a missing `initialValue`. Prefer {@link useSyncObservable} for controlled
- * inputs or when you need the strict v4 server-snapshot contract.
+ * On the server this hook never subscribes the observable and renders the resolved `initialValue`
+ * — exactly what the client's first paint will show. Prefer {@link useSyncObservable} for
+ * controlled inputs or when the value must stay consistent within the same event.
  *
  * @public
  */
@@ -44,10 +49,6 @@ export function useObservable<ObservableType extends Observable<any>>(
   options?: UseObservableOptions,
 ): ObservedValueOf<ObservableType>
 /** @public */
-export function useObservable<ObservableType extends Observable<any>>(
-  observable: ObservableType,
-): undefined | ObservedValueOf<ObservableType>
-/** @public */
 export function useObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
   initialValue: InitialValue | (() => InitialValue),
@@ -56,18 +57,23 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
 /** @public */
 export function useObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
-  initialValue?: InitialValue | (() => InitialValue),
-  options: UseObservableOptions = EMPTY_OBJECT,
+  ...args: [initialValue?: InitialValue | (() => InitialValue), options?: UseObservableOptions]
 ): InitialValue | ObservedValueOf<ObservableType> {
-  const {disabled = false} = options
+  // `undefined` (like every other value) is a valid `initialValue`, so a missing argument is
+  // detected by arity and modeled with a sentinel no caller can pass.
+  const initialValue =
+    args.length === 0 ? UNSET_INITIAL_VALUE : (args[0] as InitialValue | (() => InitialValue))
+  if (initialValue === UNSET_INITIAL_VALUE) {
+    throw missingInitialValueError('useObservable')
+  }
+  const {disabled = false} = args[1] ?? EMPTY_OBJECT
 
-  const hasInitialValue = typeof initialValue !== 'undefined'
-  // With an `initialValue` the warm-up is skipped until this hook has received an emission; after
-  // that, replacement observables are warmed during render again so that consumers that rebuild
-  // the observable on every render converge instead of looping — see `needsWarmUp`. The tracker is
-  // only ever written on commit (in `subscribe` below), never during render.
+  // The warm-up is skipped until this hook has received an emission; after that, replacement
+  // observables are warmed during render so that consumers that rebuild the observable on every
+  // render converge instead of looping — see `needsWarmUp`. The tracker is only ever written on
+  // commit (in `subscribe` below), never during render.
   const [tracker] = useState((): WarmUpTracker => ({last: null}))
-  const shouldWarmUp = needsWarmUp(tracker, observable, hasInitialValue, disabled)
+  const shouldWarmUp = needsWarmUp(tracker, observable, disabled)
   const instance = useMemo(
     () => getOrCreateStore(observable, shouldWarmUp),
     [observable, shouldWarmUp],
@@ -93,9 +99,8 @@ export function useObservable<ObservableType extends Observable<any>, InitialVal
     () => {
       return instance.getSnapshot(initialValue)
     },
-    // Always provide getServerSnapshot so SSR never throws. The server renders
-    // exactly what the client's first render will show (the resolved initialValue
-    // when provided, else a sync emission, else undefined).
+    // The server renders exactly what the client's first render will show: the resolved
+    // initialValue (or an already-warm shared entry's snapshot).
     () => instance.getSnapshot(initialValue),
   )
 

--- a/packages/react-rx/src/useSyncObservable.ts
+++ b/packages/react-rx/src/useSyncObservable.ts
@@ -3,21 +3,27 @@ import type {Observable, ObservedValueOf} from 'rxjs'
 
 import {getOrCreateStore, needsWarmUp, trackSubscribed, type WarmUpTracker} from './cache'
 import type {UseObservableOptions} from './types'
-import {EMPTY_OBJECT, getValue} from './utils'
+import {EMPTY_OBJECT, getValue, missingInitialValueError, UNSET_INITIAL_VALUE} from './utils'
 
 /**
  * Subscribe to an observable and return its latest value synchronously via
  * [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore).
  *
  * This is the v4 `useObservable` behavior. Prefer the deferred {@link useObservable} for most
- * reads. Reach for `useSyncObservable` when the value feeds a controlled input (or must stay
- * consistent within the same event), or when you need strict control over server markup: the
- * server renders the resolved `initialValue` and throws without one.
+ * reads. Reach for `useSyncObservable` when the value feeds a controlled input, or must stay
+ * consistent within the same event.
  *
- * Like {@link useObservable}, the observable is only subscribed during render (to pick up
- * synchronous emissions for the first render) when no `initialValue` is given; with an
- * `initialValue` the subscription starts on commit. Once the hook has received an emission,
- * replacement observables on later renders are warmed up during render either way, so consumers
+ * `initialValue` is required: it is what renders until the observable emits, and what the server
+ * renders. Every value is a valid initial value, `undefined` included — pass it explicitly;
+ * omitting the argument throws during render. Functions act as initializers, exactly like
+ * `useState`: pass `() => value` to compute the initial value lazily, and an initializer
+ * returning the function when the initial value should be a function itself. When there is no
+ * meaningful initial value, or you want to show fallback UI while the observable is "loading",
+ * reach for {@link useObservablePromise} with `use()` and Suspense instead.
+ *
+ * Like {@link useObservable}, the observable is not subscribed during render: the `initialValue`
+ * renders first and the live subscription starts on commit. Once the hook has received an
+ * emission, replacement observables on later renders are warmed up during render, so consumers
  * that rebuild the observable on every render settle instead of re-rendering forever.
  *
  * **Caveat:** store mutations cannot be marked as Transitions. Suspending on a value returned by
@@ -32,10 +38,6 @@ export function useSyncObservable<ObservableType extends Observable<any>>(
   options?: UseObservableOptions,
 ): ObservedValueOf<ObservableType>
 /** @public */
-export function useSyncObservable<ObservableType extends Observable<any>>(
-  observable: ObservableType,
-): undefined | ObservedValueOf<ObservableType>
-/** @public */
 export function useSyncObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
   initialValue: InitialValue | (() => InitialValue),
@@ -44,18 +46,23 @@ export function useSyncObservable<ObservableType extends Observable<any>, Initia
 /** @public */
 export function useSyncObservable<ObservableType extends Observable<any>, InitialValue>(
   observable: ObservableType,
-  initialValue?: InitialValue | (() => InitialValue),
-  options: UseObservableOptions = EMPTY_OBJECT,
+  ...args: [initialValue?: InitialValue | (() => InitialValue), options?: UseObservableOptions]
 ): InitialValue | ObservedValueOf<ObservableType> {
-  const {disabled = false} = options
+  // `undefined` (like every other value) is a valid `initialValue`, so a missing argument is
+  // detected by arity and modeled with a sentinel no caller can pass.
+  const initialValue =
+    args.length === 0 ? UNSET_INITIAL_VALUE : (args[0] as InitialValue | (() => InitialValue))
+  if (initialValue === UNSET_INITIAL_VALUE) {
+    throw missingInitialValueError('useSyncObservable')
+  }
+  const {disabled = false} = args[1] ?? EMPTY_OBJECT
 
-  const hasInitialValue = typeof initialValue !== 'undefined'
-  // With an `initialValue` the warm-up is skipped until this hook has received an emission; after
-  // that, replacement observables are warmed during render again so that consumers that rebuild
-  // the observable on every render converge instead of looping — see `needsWarmUp`. The tracker is
-  // only ever written on commit (in `subscribe` below), never during render.
+  // The warm-up is skipped until this hook has received an emission; after that, replacement
+  // observables are warmed during render so that consumers that rebuild the observable on every
+  // render converge instead of looping — see `needsWarmUp`. The tracker is only ever written on
+  // commit (in `subscribe` below), never during render.
   const [tracker] = useState((): WarmUpTracker => ({last: null}))
-  const shouldWarmUp = needsWarmUp(tracker, observable, hasInitialValue, disabled)
+  const shouldWarmUp = needsWarmUp(tracker, observable, disabled)
   const instance = useMemo(
     () => getOrCreateStore(observable, shouldWarmUp),
     [observable, shouldWarmUp],
@@ -81,8 +88,8 @@ export function useSyncObservable<ObservableType extends Observable<any>, Initia
     () => {
       return instance.getSnapshot(initialValue)
     },
-    // Strict v4 server contract: the server renders the resolved `initialValue`, and throws
-    // (missing getServerSnapshot) without one — even when the observable emits synchronously.
-    hasInitialValue ? () => getValue(initialValue) as ObservedValueOf<ObservableType> : undefined,
+    // Strict v4 server contract: the server always renders the resolved `initialValue` — even
+    // when a shared cache entry has already emitted in the same runtime.
+    () => getValue(initialValue) as ObservedValueOf<ObservableType>,
   )
 }

--- a/packages/react-rx/src/utils.ts
+++ b/packages/react-rx/src/utils.ts
@@ -1,5 +1,27 @@
 export const EMPTY_OBJECT: Readonly<Record<string, never>> = Object.freeze({})
 
+/**
+ * Sentinel representing an omitted `initialValue` argument. Every value a caller can produce —
+ * `undefined` included — is a valid initial value, so omission is detected by argument arity and
+ * modeled with a symbol user code cannot accidentally pass. Registered with `Symbol.for()` so
+ * duplicate copies of react-rx in one module graph agree on the sentinel.
+ *
+ * @internal
+ */
+export const UNSET_INITIAL_VALUE: unique symbol = Symbol.for('react-rx.unsetInitialValue')
+
+/** @internal */
+export function missingInitialValueError(hookName: string): TypeError {
+  return new TypeError(
+    `${hookName} requires an initialValue: it is rendered until the observable emits. ` +
+      'Any value is valid, `undefined` included — pass it explicitly. Functions act as ' +
+      "initializers, like React's `useState`: pass `() => value` to compute the initial value " +
+      'lazily, and an initializer returning the function when the initial value is a function ' +
+      'itself. If the observable has no meaningful initial value, use `useObservablePromise` ' +
+      'to suspend with `use()` until the first emission instead.',
+  )
+}
+
 export function getValue<T>(value: T): T extends () => infer U ? U : T {
   return (typeof value === 'function' ? (value as () => any)() : value) as T extends () => infer U
     ? U

--- a/website/src/content/guide.md
+++ b/website/src/content/guide.md
@@ -11,7 +11,8 @@ npm i react-rx rxjs
 ### Which one should I use?
 
 - **Default to `useObservable`** — store updates are deferred, so previews, validation, lists, and other chrome stay responsive and play nicely with Suspense.
-- **Reach for `useSyncObservable`** only when the value feeds a controlled input (caret/IME breakage or lost keystrokes under load) or must be read back synchronously in the same event. It is also the hook with the strict v4 SSR contract (server renders the `initialValue`, throws without one).
+- **Reach for `useSyncObservable`** only when the value feeds a controlled input (caret/IME breakage or lost keystrokes under load) or must be read back synchronously in the same event.
+- **Reach for `useObservablePromise`** when the observable has no meaningful initial value, or you want fallback UI while waiting for the first emission — it returns a `use()`-compatible promise for Suspense.
 
 See [Suspense & deferred values](/examples/suspense) for a side-by-side demo, and the [v4 → v5 migration guide](/migrate/v4-to-v5) if you are upgrading.
 
@@ -36,33 +37,30 @@ function MyComponent(props) {
 }
 ```
 
-The `initialValue` argument is optional, and it also decides how the hook treats observables that emit _synchronously_ at subscription time (`of`, `startWith`, a `BehaviorSubject`, …):
+The `initialValue` argument is **required**: it is what the component renders until the observable emits. Every value is a valid initial value — `undefined` included, pass it explicitly — and omitting the argument throws during render. Functions act as initializers, exactly like `useState`: pass `() => value` to compute the initial value lazily, and an initializer returning the function when the initial value should be a function itself.
 
-- **Without an `initialValue`**, the hook briefly subscribes during render so a synchronous emission can be returned from the very first render. If the observable only emits asynchronously, the value may be `undefined` initially.
-- **With an `initialValue`**, the observable is not subscribed during render at all. The first render shows the `initialValue`, and the subscription starts when the component commits — a synchronous emission then replaces the `initialValue` right after mount. This keeps subscribe-time side effects (for example a `fromFetch` request) out of the render phase whenever you already have a value to paint first. Once the hook has received an emission, a later render that swaps in a different observable warms the replacement during render — that is what lets components that rebuild the observable on every render settle instead of re-rendering forever.
+The observable is never subscribed during render. The first render shows the `initialValue`, and the subscription starts when the component commits — an observable that emits _synchronously_ at subscription time (`of`, `startWith`, a `BehaviorSubject`, …) replaces the `initialValue` right after mount. This keeps subscribe-time side effects (for example a `fromFetch` request) out of the render phase. Once the hook has received an emission, a later render that swaps in a different observable warms the replacement during render — that is what lets components that rebuild the observable on every render settle instead of re-rendering forever.
 
 ```tsx
 import {useMemo} from 'react'
 import {useObservable} from 'react-rx'
 import {of} from 'rxjs'
 
-// The observable emits "world" synchronously and no initialValue is given, so this
-// component renders "Hello world!" from the very first render — never an empty value.
+// The first render shows "mars"; the synchronous emission "world" takes over
+// right after mount, once the live subscription delivers it.
 function MyComponent(props) {
   const observable = useMemo(() => of('world'), [])
-  const planet = useObservable(observable)
+  const planet = useObservable(observable, 'mars')
 
   return <>Hello {planet}!</>
 }
 ```
 
-Had this component passed an `initialValue` — `useObservable(observable, 'mars')` — the first render would show `"mars"`, with `"world"` taking over right after mount once the live subscription delivers the synchronous emission.
+If there is no initial value that makes sense for your observable — or you want to show fallback UI while the observable is "loading" — that is what [`useObservablePromise`](#useobservablepromise) is for: it returns a `use()`-compatible promise that suspends until the first emission instead of painting a placeholder value.
 
-The difference between `useObservable` and `useSyncObservable` is how _updates_ propagate (deferred vs synchronous), not the first render. On the server, `useObservable` paints what the first client render will show — a synchronous emission when no `initialValue` is given (here `"world"`), else the resolved `initialValue` — and never throws, while `useSyncObservable` always paints the `initialValue` and throws without one.
+The difference between `useObservable` and `useSyncObservable` is how _updates_ propagate (deferred vs synchronous), not the first render. On the server both hooks render the resolved `initialValue` — exactly what the first client paint will show — and neither ever subscribes the observable there.
 
-The `disabled` option pauses the hook's _active_ subscription — think of it like `pause: true`. While `disabled` is `true`, the hook will not keep a live subscription that pushes updates into the component, and it returns the last value it already received (or the `initialValue` if nothing has been received yet). Turning `disabled` back to `false` resumes the live subscription.
-
-Important: when no `initialValue` is given, `disabled` does **not** skip the hook's warm-up subscription — both hooks still briefly subscribe during render so a synchronous emission can become the current snapshot, which means cold observables with subscribe-time side effects (for example `fromFetch`) still run that work even when `disabled` is `true`. With an `initialValue` there is no warm-up at all while disabled, so `disabled: true` guarantees zero subscriptions until it is re-enabled — even when the observable is rebuilt on every render.
+The `disabled` option pauses the hook's _active_ subscription — think of it like `pause: true`. While `disabled` is `true`, the hook will not keep a live subscription that pushes updates into the component, and it returns the last value it already received (or the `initialValue` if nothing has been received yet). Turning `disabled` back to `false` resumes the live subscription. A disabled hook performs no subscriptions at all — even when the observable is rebuilt on every render — so `disabled: true` guarantees zero subscriptions until it is re-enabled.
 
 ```tsx
 import {useEffect, useState} from 'react'
@@ -83,7 +81,7 @@ function MyComponent(props) {
 }
 ```
 
-If the goal is to avoid _any_ subscription to a particular observable, the simplest option is to combine an `initialValue` with `disabled` — the observable is never warmed up while disabled, so nothing subscribes until `disabled` flips to `false`:
+That guarantee makes `disabled` the tool for gating observables with subscribe-time side effects:
 
 ```tsx
 import {useMemo} from 'react'
@@ -98,39 +96,14 @@ function Users({shouldFetch}: {shouldFetch: boolean}) {
       }),
     [],
   )
-  // With an initialValue there is no render-phase warm-up, so the request is
-  // guaranteed not to fire until `shouldFetch` becomes true.
+  // Nothing subscribes during render, and `disabled` skips the commit-time
+  // subscription too — the request is guaranteed not to fire until
+  // `shouldFetch` becomes true.
   const users = useObservable(users$, null, {disabled: !shouldFetch})
 
   return <pre>{JSON.stringify(users, null, 2)}</pre>
 }
 ```
-
-When you cannot provide an `initialValue` (you want the synchronous emission on the first render), `disabled` alone is not enough — the warm-up subscribe would still fire the request. In that case pass a different observable instead, for example swap in `of(null)` until you are ready to fetch:
-
-```tsx
-import {useMemo} from 'react'
-import {useObservable} from 'react-rx'
-import {of} from 'rxjs'
-import {fromFetch} from 'rxjs/fetch'
-
-function Users({shouldFetch}: {shouldFetch: boolean}) {
-  const users$ = useMemo(
-    () =>
-      shouldFetch
-        ? fromFetch('https://api.github.com/users?per_page=5', {
-            selector: (response) => response.json(),
-          })
-        : of(null),
-    [shouldFetch],
-  )
-  const users = useObservable(users$)
-
-  return <pre>{JSON.stringify(users, null, 2)}</pre>
-}
-```
-
-Because the fetch observable is only created (and therefore only ever subscribed) when `shouldFetch` is true, this guarantees zero subscriptions to `fromFetch` until then.
 
 ### useSyncObservable()
 
@@ -246,7 +219,7 @@ useObservablePromise(observable$, {
 })
 ```
 
-Unlike `useObservable`'s `disabled` (which still runs a warm-up probe when no `initialValue` is given), `disabled: true` here fully prevents fetching on behalf of this component: it skips the commit-time store subscription, so it also receives no re-render notifications for later emissions. The returned promise is still the shared cache entry — a sibling or `preloadObservablePromise` can warm it.
+Like `useObservable`'s `disabled`, `disabled: true` fully prevents fetching on behalf of this component: it skips the commit-time store subscription, so it also receives no re-render notifications for later emissions. The returned promise is still the shared cache entry — a sibling or `preloadObservablePromise` can warm it.
 
 `ttl` controls how long a settled value stays reusable after unmount. Remount within the window reuses the promise (no refetch, no fallback). After it expires, the next mount refetches. Eviction only affects future consumers: components that are still mounted keep their value — hiding an `<Activity>` tree longer than `ttl` never drops what it already rendered.
 
@@ -297,7 +270,7 @@ function TabButton({users$, onSelect}) {
 
 react-rx is a **client-only** library — every export ships behind `'use client'`, and observables are **never subscribed on the server**. A server-started subscription has no unmount to tear it down, a never-settling source would keep it (and the response stream) alive forever, and the module-scope promise cache would be shared across requests. Concretely:
 
-- `useObservable` / `useSyncObservable` server-render like `useSyncExternalStore`: the server paints the server snapshot (documented per hook above) and the live subscription starts on the client.
+- `useObservable` / `useSyncObservable` server-render like `useSyncExternalStore`: the server paints the resolved `initialValue` and the live subscription starts on the client.
 - `useObservablePromise` returns a pending promise on the server, so server rendering emits the Suspense fallback; the fetch starts on the client once the hydrated hook caller commits.
 - `preloadObservablePromise` is a no-op on the server: it returns an inert, forever-pending promise and subscribes nothing, so preloads in shared/isomorphic code (route loaders) only take effect in the browser.
 
@@ -305,12 +278,12 @@ This is not the library for React Server Components or server-only data flows. H
 
 **Which hook when?**
 
-| Need                                                   | Hook                   |
-| ------------------------------------------------------ | ---------------------- |
-| Live values, timers, subjects, optional `initialValue` | `useObservable`        |
-| Controlled inputs / synchronous store updates          | `useSyncObservable`    |
-| Async data + Suspense / Activity pre-render            | `useObservablePromise` |
-| Event → observable pipelines                           | `useObservableEvent`   |
+| Need                                                | Hook                   |
+| --------------------------------------------------- | ---------------------- |
+| Live values, timers, subjects (with `initialValue`) | `useObservable`        |
+| Controlled inputs / synchronous store updates       | `useSyncObservable`    |
+| No meaningful `initialValue`, Suspense, Activity    | `useObservablePromise` |
+| Event → observable pipelines                        | `useObservableEvent`   |
 
 For cold observables you want to share across subscribers yourself, keep using RxJS `shareReplay({bufferSize: 1, refCount: true})` — the hook's `ttl` is a lightweight mount/unmount cache, not a full query cache.
 

--- a/website/src/content/migrate/v4-to-v5.mdx
+++ b/website/src/content/migrate/v4-to-v5.mdx
@@ -20,14 +20,14 @@ In v4, `useObservable` was built on [`useSyncExternalStore`](https://react.dev/r
 v5 makes that the library default:
 
 - **`useObservable`** — store updates are deferred with `useDeferredValue`. Urgent renders keep the previous value; a background render catches up. Mounts, remounts, and `<Activity>` reveals still show the live snapshot (no initial-value flash). The deferral is identity-coherent: when the observable identity changes, the hook falls back to the live value so the previous observable's value never renders under the new one — a stale-value bug a hand-rolled `useDeferredValue(useObservable(...))` wrapper is prone to.
-- **`useSyncObservable`** — exact v4 synchronous behavior, including the strict server snapshot (`initialValue` on the server, throws without one).
+- **`useSyncObservable`** — exact v4 synchronous behavior, including the strict server snapshot (the server renders the resolved `initialValue`).
 
 ### What you may notice
 
 - **Controlled inputs** can lag or lose caret position under load if they keep using `useObservable` — switch those reads to `useSyncObservable`.
 - The **rendered value can briefly trail the store**, so imperative reads or equality checks against it can observe a stale value. Keep a sync read for write-path equality when needed.
 - **Render-count / test assertions** may see extra passes: one Object.is bail-out pass on mount when the snapshot is defined, and an urgent-plus-deferred pair per emission.
-- **SSR** no longer throws when `initialValue` is omitted: without one, the server renders a synchronous emission (or nothing). Non-deterministic sync emissions can then surface hydration mismatches, and synchronously erroring observables fail the server render instead of exploding at hydration. With an `initialValue` the server keeps painting it, as in v4 — since v6 the observable is not subscribed during render at all in that case.
+- **`initialValue` is required since v7** for both hooks: any value works (`undefined` included — pass it explicitly; functions act as `useState`-style initializers), and omitting the argument throws during render — on the server too. The observable is never subscribed during (server or first client) render, so the server always paints the resolved `initialValue`. Observables without a meaningful initial value belong to `useObservablePromise` instead.
 
 ### Recommended: targeted migration
 
@@ -49,8 +49,8 @@ Also remove redundant wrappers that are now built in:
 // Before
 const results = useDeferredValue(useObservable(results$))
 
-// After
-const results = useObservable(results$)
+// After (initialValue is required since v7 — undefined must be passed explicitly)
+const results = useObservable(results$, undefined)
 ```
 
 ### Fallback: mechanical rename

--- a/website/src/content/reference.mdx
+++ b/website/src/content/reference.mdx
@@ -6,26 +6,32 @@ A React hook that returns the current/latest value from an observable. Store upd
 
 The deferral is **identity-coherent**: unlike a bare `useDeferredValue(useObservable(...))`, the observable identity and its value are deferred as one snapshot, and when the observable identity changes (e.g. it is memoized on a document id that just changed) the hook falls back to the live value — typically the new observable's synchronous emission or the `initialValue` — so the previous identity's value never renders under the new one.
 
-Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash once a value has been emitted). When no `initialValue` is given, the hook briefly subscribes during render so a synchronous emission (e.g. from `startWith`) is available from the very first render; with an `initialValue` the observable is not subscribed during render — the `initialValue` paints first and the live subscription starts on commit, keeping subscribe-time side effects out of the render phase. Once the hook has received an emission, replacement observables on later renders are warmed during render again — that is what lets components that rebuild the observable on every render settle instead of re-rendering forever; before the first emission (and always while `disabled`), identity churn stays subscription-free. On the server, this hook renders exactly what the client's first paint will show (the resolved `initialValue` when one is provided, else a synchronous emission when there is one, else nothing) and never throws for a missing `initialValue`.
+`initialValue` is **required**: it is what renders until the observable emits. Every value is a valid initial value — `undefined` included, pass it explicitly — and omitting the argument throws during render. Functions act as initializers, exactly like `useState`: pass `() => value` to compute the initial value lazily, and an initializer returning the function when the initial value should be a function itself. When there is no meaningful initial value, use [`useObservablePromise`](#useobservablepromise) instead.
 
-Prefer this hook for previews, validation, lists, and other non-input reads. Use [`useSyncObservable`](#usesyncobservable) for controlled inputs or strict SSR control.
+Mounts, remounts, and `<Activity>` reveals still render the current snapshot synchronously (no initial-value flash once a value has been emitted). The observable is not subscribed during render — the `initialValue` paints first and the live subscription starts on commit, keeping subscribe-time side effects out of the render phase. Once the hook has received an emission, replacement observables on later renders are warmed during render — that is what lets components that rebuild the observable on every render settle instead of re-rendering forever; before the first emission (and always while `disabled`), identity churn stays subscription-free. On the server, this hook renders the resolved `initialValue` — exactly what the client's first paint will show — and never subscribes the observable.
+
+Prefer this hook for previews, validation, lists, and other non-input reads. Use [`useSyncObservable`](#usesyncobservable) for controlled inputs.
 
 **Signature**
 
 ```ts
-function useObservable<T>(observable$: Observable<T>): T | undefined
 function useObservable<T>(
   observable$: Observable<T>,
   initialValue: T | (() => T),
   options?: UseObservableOptions,
 ): T
+function useObservable<T, InitialValue>(
+  observable$: Observable<T>,
+  initialValue: InitialValue | (() => InitialValue),
+  options?: UseObservableOptions,
+): T | InitialValue
 
 interface UseObservableOptions {
   disabled?: boolean
 }
 ```
 
-`disabled` pauses the live subscription (later emissions stop updating the component; the last value is kept). When no `initialValue` is given the render-phase warm-up subscription still runs; with an `initialValue` there is no warm-up while disabled, so `disabled: true` means zero subscriptions — see the [guide](/guide).
+`disabled` pauses the live subscription (later emissions stop updating the component; the last value is kept). A disabled hook performs no subscriptions at all — `disabled: true` means zero subscriptions until it is re-enabled — see the [guide](/guide).
 
 **Example**
 
@@ -46,19 +52,25 @@ function MyComponent() {
 
 A React hook that returns the current/latest value from an observable **synchronously** via [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore). This is the v4 `useObservable` behavior.
 
-Use it when the value feeds a controlled input (or must stay consistent within the same event), or when you need strict control over server markup: the server renders the resolved `initialValue` and throws without one.
+Use it when the value feeds a controlled input, or must stay consistent within the same event.
+
+`initialValue` is **required** and follows the same rules as [`useObservable`](#useobservable): every value is valid (`undefined` included), functions act as `useState`-style initializers, and omitting the argument throws during render. The server always renders the resolved `initialValue`.
 
 **Caveat:** store mutations cannot be marked as Transitions. Suspending on a value returned by this hook replaces already-visible content with the nearest Suspense fallback — see the [useSyncExternalStore caveats](https://react.dev/reference/react/useSyncExternalStore#caveats). Compare the two hooks in the [Suspense example](/examples/suspense).
 
 **Signature**
 
 ```ts
-function useSyncObservable<T>(observable$: Observable<T>): T | undefined
 function useSyncObservable<T>(
   observable$: Observable<T>,
   initialValue: T | (() => T),
   options?: UseObservableOptions,
 ): T
+function useSyncObservable<T, InitialValue>(
+  observable$: Observable<T>,
+  initialValue: InitialValue | (() => InitialValue),
+  options?: UseObservableOptions,
+): T | InitialValue
 ```
 
 **Example**

--- a/website/src/examples/fetch/FetchExample.tsx
+++ b/website/src/examples/fetch/FetchExample.tsx
@@ -49,7 +49,7 @@ function FetchExample() {
   )
 
   const currentUrl = useObservable(url$, '')
-  const response = useObservable(response$)
+  const response = useObservable(response$, null)
 
   return (
     <div>

--- a/website/src/examples/fizz-buzz/FizzBuzzExample.tsx
+++ b/website/src/examples/fizz-buzz/FizzBuzzExample.tsx
@@ -24,5 +24,5 @@ const observable = timer(0, 500).pipe(
 )
 
 export default function App() {
-  return useObservable(observable)
+  return useObservable(observable, null)
 }

--- a/website/src/examples/hello-world/HelloWorldExample.tsx
+++ b/website/src/examples/hello-world/HelloWorldExample.tsx
@@ -4,7 +4,7 @@ import {of} from 'rxjs'
 const observable = of('World')
 
 export default function App() {
-  const data = useObservable(observable)
+  const data = useObservable(observable, '…')
 
   return <h1>Hello, {data}!</h1>
 }

--- a/website/src/examples/reactive-state/ReactiveStateExample.tsx
+++ b/website/src/examples/reactive-state/ReactiveStateExample.tsx
@@ -1,6 +1,6 @@
 import {useMemo, useState} from 'react'
 import {useObservable} from 'react-rx'
-import {map, startWith, timer} from 'rxjs'
+import {map, timer} from 'rxjs'
 
 export default function App() {
   const [delay, setDelay] = useState(500)
@@ -8,12 +8,14 @@ export default function App() {
     () =>
       timer(500, delay).pipe(
         map((n) => `Count: ${n}`),
-        startWith('Starting counter…'),
       ),
     [delay],
   )
 
-  const label = useObservable(observable)
+  const label = useObservable(
+    observable,
+    'Starting counter…',
+  )
   return (
     <>
       Counter interval (ms):{' '}

--- a/website/src/examples/search/SearchExample.tsx
+++ b/website/src/examples/search/SearchExample.tsx
@@ -97,7 +97,7 @@ function SearchExample() {
   // Controlled input value must update synchronously.
   const keyword = useSyncObservable(keyword$, '')
   // Results are deferred by default via useObservable (no manual useDeferredValue).
-  const results = useObservable(results$)
+  const results = useObservable(results$, null)
 
   return (
     <>

--- a/website/src/examples/simple/Counter.example.tsx
+++ b/website/src/examples/simple/Counter.example.tsx
@@ -4,6 +4,6 @@ import {timer} from 'rxjs'
 const observable = timer(0, 1000)
 
 export default function App() {
-  const seconds = useObservable(observable)
+  const seconds = useObservable(observable, 0)
   return <>Seconds: {seconds}</>
 }

--- a/website/src/examples/sync/Sync.example.tsx
+++ b/website/src/examples/sync/Sync.example.tsx
@@ -2,15 +2,19 @@ import {useObservable} from 'react-rx'
 import {from} from 'rxjs'
 
 const observable = from([
-  'This',
-  'will',
-  'only',
+  'Sync',
+  'emissions',
   'render',
-  'once!',
+  'right',
+  'after',
+  'mount!',
 ])
 
 function Sync() {
-  const message = useObservable(observable)
+  // The initialValue paints first; every synchronous
+  // emission arrives right after mount, so only the
+  // last one is ever visible.
+  const message = useObservable(observable, '…')
 
   return <>{message}</>
 }

--- a/website/src/examples/tick/Ticker.tsx
+++ b/website/src/examples/tick/Ticker.tsx
@@ -4,7 +4,6 @@ import {
   distinctUntilChanged,
   map,
   type Observable,
-  startWith,
   switchMap,
   timer,
 } from 'rxjs'
@@ -19,11 +18,10 @@ export function Ticker(props: {
         switchMap((tick) =>
           timer(300).pipe(map(() => tick)),
         ),
-        startWith(0),
       ),
     [props.observable],
   )
-  const tick = useObservable(observable)
+  const tick = useObservable(observable, 0)
 
   return <p>Delayed tick: {tick}</p>
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`initialValue` is now a **required** argument for `useObservable` and `useSyncObservable`. Omitting it is a type error, and — since JavaScript callers can bypass the types — the hooks also detect a missing argument at runtime and throw during render. Omission is detected by argument arity and modeled internally with the `Symbol.for('react-rx.unsetInitialValue')` sentinel, because every value a caller can actually pass is a valid initial value:

- **Every value is valid, `undefined` included** — it just has to be passed explicitly. `useObservable(value$, undefined)` renders `undefined` until the first emission; `useObservable(value$)` throws.
- **Functions act as initializers**, exactly like `useState`: `useObservable(value$, () => expensiveInitial())` computes the initial value lazily, and a function initial value is provided via an initializer that returns it (`useObservable(fn$, () => myFunction)`).

Observables with no good initial value — or flows that want fallback UI while the observable is "loading" — belong to `useObservablePromise` instead.

## Internal simplification

With an `initialValue` always present, the no-initial-value code paths are gone:

- The render-phase warm-up subscription for the hooks' *initial* observable no longer exists — the observable is **never** subscribed during render for its first paint (`needsWarmUp` lost its `hasInitialValue` branch). The only remaining warm-up is for replacement observables after the first emission, which is the anti-loop mechanism for consumers that rebuild the observable on every render.
- `disabled: true` now always guarantees zero subscriptions (previously the warm-up probe still subscribed once when no `initialValue` was given).
- Server rendering is uniform: both hooks render the resolved `initialValue` and never subscribe the observable. `useSyncObservable` no longer hits React's "Missing getServerSnapshot" error, and non-deterministic synchronous emissions can no longer cause hydration mismatches.

## Changes

- `packages/react-rx/src/utils.ts` — `UNSET_INITIAL_VALUE` sentinel (`Symbol.for`) + `missingInitialValueError`.
- `packages/react-rx/src/useObservable.ts`, `useSyncObservable.ts` — dropped the no-initial-value overload, arity-based omission detection + render-phase throw, updated docs.
- `packages/react-rx/src/cache.ts` — `needsWarmUp` simplified (no `hasInitialValue` parameter).
- Tests — new `requiredInitialValue.test.tsx` suite (throws on omission during client render and SSR, nothing subscribes before the throw, explicit `undefined` works, `useState`-style function-initializer parity); all existing suites updated to the new contract, including reworked leak-regression and warm-up-blip scenarios that now exercise the replacement warm-up path.
- Website + README — examples pass explicit initial values, guide/reference document the required argument, the v4→v5 migration page notes the v7 requirement.
- Changeset: major (folds into the v7 prerelease line).

## Testing

- `pnpm test` — 50 files, 444 tests passing (+4 expected type-error assertions), typecheck clean, both the default and `react-compiler` Vitest projects.
- `pnpm lint`, `pnpm build`, `pnpm knip` — clean.
- Website examples verified in the dev server.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64c22600-f645-461f-a0da-ffb67386479b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64c22600-f645-461f-a0da-ffb67386479b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

