### PR TITLE
docs: cover all three v7 breaking changes in the migration guide

### DIFF
--- a/website/src/content/migrate/v6-to-v7.mdx
+++ b/website/src/content/migrate/v6-to-v7.mdx
@@ -1,16 +1,77 @@
 # Migrating from v6 to v7
 
-v7 removes the `useObservableEvent` hook. This page covers why, and how to migrate each usage shape.
+v7 has three breaking changes, all pushing in the same direction — subscriptions are strictly commit-driven, and event handling uses plain RxJS instead of a library-specific hook:
 
-## Why it was removed
+1. [`initialValue` is now required](#initialvalue-is-now-required) in `useObservable` and `useSyncObservable`.
+2. [`useObservablePromise` fetches start at commit](#useobservablepromise-fetches-start-at-commit), never during render.
+3. [`useObservableEvent` is removed](#useobservableevent-is-removed).
+
+Requirements are unchanged from v5: React `^19.2`, RxJS `^7.2`, Node `>=22.12`, ESM-only.
+
+## initialValue is now required
+
+The initial value is what renders until the observable emits. Omitting the argument is now a type error, and since JavaScript callers can bypass the types, the hooks also throw during render when it is missing.
+
+```tsx
+// Before (v6) — implicitly undefined until the first emission
+const users = useObservable(users$)
+
+// After (v7) — pass the initial value explicitly
+const users = useObservable(users$, undefined)
+```
+
+Every value is valid, `undefined` included — it just has to be passed explicitly. Functions act as initializers, exactly like `useState`: `useObservable(value$, () => expensiveInitial())` computes lazily, and to use a function itself as the initial value, pass an initializer that returns it.
+
+Call sites that already pass an `initialValue` are unaffected, including their runtime behavior.
+
+### What you may notice
+
+- **No render-phase warm-up on mount.** Without an `initialValue`, v6 briefly subscribed during render so a synchronous emission (`of`, `startWith`, a `BehaviorSubject`, …) could win the very first paint. In v7 the observable is never subscribed during render for its first paint: the `initialValue` renders first and the synchronous emission replaces it right after mount. If an observable has no initial value that makes sense — you want fallback UI while it "loads" — that is `useObservablePromise` with `use()` and Suspense.
+- **`disabled: true` now always guarantees zero subscriptions.** Previously the warm-up probe still subscribed once when no `initialValue` was given.
+- **Server rendering is uniform.** Both hooks render the resolved `initialValue` and never subscribe the observable on the server. `useSyncObservable` can no longer hit React's "Missing getServerSnapshot" error, and non-deterministic synchronous emissions can no longer cause hydration mismatches.
+
+## useObservablePromise fetches start at commit
+
+The hook no longer subscribes the source observable during render. Previously rendering — including hidden `<Activity>` pre-renders — triggered fetching as a side effect. Fetching is now strictly commit-driven or explicit: the source subscription starts when a non-`disabled` component that called the hook **commits**, or when `preloadObservablePromise` is called.
+
+What to change:
+
+- **`use(useObservablePromise(obs$))` in a single component now deadlocks** — the component suspends on its own pending promise before the commit that would start the fetch. This was never a supported pattern and is intentionally not guarded against. Pass the promise as a prop to a child that reads it with `use()`, with a `<Suspense>` boundary **between** the hook caller and that child, so the caller can commit while the child suspends:
+
+```tsx
+// Broken in v7 — suspends before the commit that would start the fetch
+function Users() {
+  const users = use(useObservablePromise(users$))
+  return <pre>{JSON.stringify(users, null, 2)}</pre>
+}
+
+// Works — the hook caller commits, the child suspends
+function Users() {
+  const promise = useObservablePromise(users$)
+  return (
+    <Suspense fallback={<p>Loading users…</p>}>
+      <UsersList promise={promise} />
+    </Suspense>
+  )
+}
+
+function UsersList({promise}: {promise: Promise<unknown>}) {
+  return <pre>{JSON.stringify(use(promise), null, 2)}</pre>
+}
+```
+
+- **Hidden `<Activity>` trees no longer fetch.** A hidden tree that calls the hook is fully paused — no subscription until it is revealed and effects mount. To pre-render hidden content _with_ data, call the hook in a visible parent and pass the promise into the hidden tree, where `use(promise)` lets React pre-render and suspend on its own terms. See the [Activity and preload example](/examples/activity).
+- **Synchronously-emitting sources show one fallback pass on a cold mount** (`of`, `BehaviorSubject`, replayed `shareReplay`): they now resolve at the hook caller's commit instead of during render. Preload the observable to render them without a fallback.
+- **Swapping observables inside `startTransition` / behind `useDeferredValue` requires warming the new observable first** (for example `preloadObservablePromise` in the event handler): a transition render that suspends never commits, so it can no longer start the fetch.
+- **On the server, `preloadObservablePromise` is a no-op** (an inert pending promise; no subscription, no cache entry) — react-rx never subscribes observables on the server. Server rendering emits the Suspense fallback and the fetch starts after hydration. For React Server Components or server-only flows, fetch with async/await or RxJS [`firstValueFrom`](https://rxjs.dev/api/index/function/firstValueFrom) and pass the promise or value down as a prop.
+
+## useObservableEvent is removed
 
 `useObservableEvent` was layers of abstraction over a plain RxJS `Subject`: it created one internally, returned `subject.next` as a stable callback, and subscribed the pipeline you returned in an effect. The same thing is expressed directly with a `Subject` you own — fewer moving parts, no library-specific event concept to learn, and a mental model that carries straight over to the upcoming [native Observable API](https://github.com/WICG/observable).
 
 The removal also drops the hook's `use-effect-event` dependency, leaving `react-rx` with no runtime dependencies beyond its `react` and `rxjs` peers.
 
-## Migration
-
-Create a `Subject`, call `subject.next(...)` where you previously called the returned handler, and move the pipeline to where its output is consumed.
+To migrate, create a `Subject`, call `subject.next(...)` where you previously called the returned handler, and move the pipeline to where its output is consumed.
 
 ### Pipelines that updated state
 
@@ -69,7 +130,7 @@ useEffect(() => {
 const handleSave = (term: string) => saves$.next(term)
 ```
 
-## Semantics to be aware of
+### Semantics to be aware of
 
 - `useObservableEvent` subscribed its pipeline in an effect after mount, so events fired before that were dropped. A `Subject` read through the hooks starts its live subscription on commit as well, and event handlers can only fire after mount — no change in practice.
 - The returned handler was referentially stable. An inline `(v) => subject$.next(v)` is a new function per render; if a memoized child needs a stable callback, wrap it in `useCallback` or pass the subject itself down.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#518](https://github.com/sanity-io/react-rx/pull/518): the `migrate/v6-to-v7` page previously documented only the `useObservableEvent` removal, but v7 also carries two other breaking changes with no migrate-page entries. This extends the page to cover all three, distilled from their changesets into actionable migration steps:

1. **`initialValue` is now required** in `useObservable`/`useSyncObservable` ([#517](https://github.com/sanity-io/react-rx/pull/517)) — the explicit-`undefined` rule, function-as-initializer semantics, and the "what you may notice" fallout: no render-phase warm-up on mount, `disabled: true` meaning zero subscriptions, and uniform SSR.
2. **`useObservablePromise` fetches start at commit** ([#510](https://github.com/sanity-io/react-rx/pull/510)) — the single-component `use(useObservablePromise(...))` deadlock with a broken/working code pair, paused hidden `<Activity>` trees, the one-fallback-pass behavior of sync sources, preloading before transitions, and the server no-op.
3. **`useObservableEvent` is removed** — the existing content from #518, restructured under the new page layout.

The intro links each section with anchors (verified against Nextra's generated heading ids) and notes that requirements are unchanged from v5.

## Verification

- Page renders at `/migrate/v6-to-v7` on the dev server with all three section headings and matching anchor ids.
- Content is sourced from the `.changeset/require-initial-value.md` and `.changeset/no-render-phase-fetching.md` changesets so the guidance matches the shipped behavior descriptions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5756f09b-70da-49a7-bb6e-f608408076b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5756f09b-70da-49a7-bb6e-f608408076b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

